### PR TITLE
Added changes to support warn logs

### DIFF
--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	// TODO change log library - https://github.com/dell/csi-baremetal/issues/351
 	"github.com/go-logr/logr"
 
 	csibaremetalv1 "github.com/dell/csi-baremetal-operator/api/v1"
@@ -59,9 +58,7 @@ func (r *DeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	err := r.Client.Get(ctx, client.ObjectKey{Name: req.Name, Namespace: req.Namespace}, deployment)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// TODO set logLevel as Warn after changing log library
-			// https://github.com/dell/csi-baremetal/issues/351
-			log.Info("Custom resource is not found")
+			log.V(-1).Info("Custom resource is not found")
 			return ctrl.Result{}, nil
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	go.uber.org/zap v1.10.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 
+	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -54,7 +55,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	stackTraceLevel := uberzap.NewAtomicLevelAt(uberzap.ErrorLevel)
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.StacktraceLevel(&stackTraceLevel)))
 
 	config := ctrl.GetConfigOrDie()
 	clientSet, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
Signed-off-by: Kesavan <kesavan96.cse@gmail.com>

## Purpose
### Issue dell/csi-baremetal#351

_Describe your changes_
Added changes to support warn messages in the existing `github.com/go-logr/logr` interface
- Used verbosity level to log warn messages
- When dev mode enabled (`zap.UseDevMode(true)`), default stackTraceLevel is `Warn`. Thus increased the stackTraceLevel to `Error` so `Warn` stacktrace is ignored.

## PR checklist
- [x] Add link to the issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Testing details_
