### PR TITLE
[ISSUE-423] Fix incorrect extender port parameter in csi-deployment chart

### DIFF
--- a/charts/csi-baremetal-deployment/templates/configmap/patcher-configmap.yaml
+++ b/charts/csi-baremetal-deployment/templates/configmap/patcher-configmap.yaml
@@ -24,7 +24,7 @@ data:
     apiVersion: v1
     kind: Policy
     extenders:
-      - urlPrefix: "http://127.0.0.1:{{ .Values.scheduler.patcher.extender_port }}"
+      - urlPrefix: "http://127.0.0.1:{{ .Values.scheduler.extender.port }}"
         filterVerb: filter
         prioritizeVerb: prioritize
         weight: 1
@@ -38,7 +38,7 @@ data:
     apiVersion: kubescheduler.config.k8s.io/v1beta1
     kind: KubeSchedulerConfiguration
     extenders:
-      - urlPrefix: "http://127.0.0.1:{{ .Values.scheduler.patcher.extender_port }}"
+      - urlPrefix: "http://127.0.0.1:{{ .Values.scheduler.extender.port }}"
         filterVerb: filter
         prioritizeVerb: prioritize
         weight: 1


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#423

Fix extender port parameter passed into `schedulerpatcher-config` configmap
Regression from https://github.com/dell/csi-baremetal-operator/pull/39

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Testing details_
