### PR TITLE
[ISSUE-436] Always patch Scheduler config on OpenShift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v0.3.0
 	github.com/openshift/api v0.0.0-20200618202633-7192180f496a
-	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/stretchr/testify v1.5.1
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#436

When Extender ConfigMap is already exist Operator skips Scheduler config pathing. As a result configuration might not be fully applied when CSI was uninstalled incorrectly. Thus PVC will stuck in pending state.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Manually tested with pre-installed ConfgiMap:
```
2021-06-24T10:28:43.367Z        INFO    controller-runtime.manager.controller.csi-controller    Starting workers        {"worker count": 1}
2021-06-24T10:28:43.367Z        INFO    controllers.Deployment  Custom resource obtained        {"deployment": "default/csi-baremetal"}
2021-06-24T10:28:43.657Z        INFO    ConfigMap is already patched    {"csi-baremetal": "patcher"}
```
Scheduler was patched:
```
[root@servicenode ~]# kubectl describe scheduler cluster
...
Spec:
  Masters Schedulable:  true
  Policy:
    Name:  scheduler-policy
```