### PR TITLE
[ISSUE-417] Bump memory limit for OpenShift

### DIFF
--- a/charts/csi-baremetal-operator/templates/manager.yaml
+++ b/charts/csi-baremetal-operator/templates/manager.yaml
@@ -34,7 +34,7 @@ spec:
           # Memory limit is increased due to bug in OpenShift 4.6 - https://bugzilla.redhat.com/show_bug.cgi?id=1904558
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#417

Need to increase memory limit from 100 to 200 MiB to work on OpenShift.

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Tested manually
