### PR TITLE
[ISSUE-500] third party extenders

### DIFF
--- a/api/v1/components/patcher.go
+++ b/api/v1/components/patcher.go
@@ -18,6 +18,7 @@ package components
 
 // Patcher represents scheduler patcher container, which tries to patch Kubernetes scheduler
 type Patcher struct {
+	Enable            bool   `json:"enable"`
 	Image             *Image `json:"image,omitempty"`
 	Interval          int    `json:"interval,omitempty"`
 	RestoreOnShutdown bool   `json:"restoreOnShutdown,omitempty"`

--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -87,6 +87,7 @@ spec:
       port: {{ .Values.scheduler.metrics.port }}
     extenderPort: {{ .Values.scheduler.extender.port | quote }}
     patcher:
+      enable: {{ .Values.scheduler.patcher.enable }}
       image:
         name: csi-baremetal-scheduler-patcher
         tag: {{ .Values.scheduler.patcher.image.tag | default .Values.image.tag }}

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -1,6 +1,6 @@
 # Docker registry to pull images
 global:
-  registry: docker.io/objectscale
+  registry:
   registrySecret:
 
 # Image pull settings
@@ -132,7 +132,7 @@ scheduler:
     # option to enable Kubernetes scheduler configuration patching to use csi extender
     # platform field must be also set to the one of supported from pkg/constant/platforms.go
     # NOTE: use with caution - will overwrite existing configuration
-    enable: true
+    enable: false
 
     image:
       tag:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -43,7 +43,7 @@ driver:
       tag:
 
   drivemgr:
-    type: halmgr
+    type: basemgr
     image:
       tag:
     grpc:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -129,6 +129,9 @@ scheduler:
 
   # Patcher settings
   patcher:
+    # option to enable Kubernetes scheduler configuration patching to use csi extender
+    # platform field must be also set to the one of supported from pkg/constant/platforms.go
+    # NOTE: use with caution - will overwrite existing configuration
     enable: false
 
     image:
@@ -165,4 +168,5 @@ nodeController:
     port: 8787
 
 # TODO Move parameter to Operator chart - https://github.com/dell/csi-baremetal/issues/422
+# platform field must be set to the one of supported from pkg/constant/platforms.go
 platform: "vanilla"

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -1,6 +1,6 @@
 # Docker registry to pull images
 global:
-  registry:
+  registry: docker.io/objectscale
   registrySecret:
 
 # Image pull settings
@@ -43,7 +43,7 @@ driver:
       tag:
 
   drivemgr:
-    type: basemgr
+    type: halmgr
     image:
       tag:
     grpc:
@@ -132,7 +132,7 @@ scheduler:
     # option to enable Kubernetes scheduler configuration patching to use csi extender
     # platform field must be also set to the one of supported from pkg/constant/platforms.go
     # NOTE: use with caution - will overwrite existing configuration
-    enable: false
+    enable: true
 
     image:
       tag:

--- a/charts/csi-baremetal-operator/values.yaml
+++ b/charts/csi-baremetal-operator/values.yaml
@@ -1,6 +1,6 @@
 # Docker registry to pull images
 global:
-  registry: docker.io/objectscale
+  registry:
   registrySecret:
 
 # Image pull settings

--- a/charts/csi-baremetal-operator/values.yaml
+++ b/charts/csi-baremetal-operator/values.yaml
@@ -1,6 +1,6 @@
 # Docker registry to pull images
 global:
-  registry:
+  registry: docker.io/objectscale
   registrySecret:
 
 # Image pull settings

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -2,7 +2,8 @@ Manual Kubernetes Scheduler Configuration
 ---------------------
 To make CSI work correctly we maintain Kubernetes scheduler extender and scheduler extender patcher components.
 If your Kubernetes distributive is not in the list of supported or you have third party scheduler extender deployed the
-following manual steps are required
+following manual steps are required on all master nodes (except OpenShift). Note that user must wait for all scheduler
+pods to restart after configuration change.
 * Vanilla Kubernetes
     * If you have third party scheduler extender deployed add the following sections to your configuration file
     ```yaml

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -6,6 +6,49 @@ following manual steps are required
 * Vanilla Kubernetes
     * Version 1.18 and below
     * Version 1.19 and above
+        * Create configuration file _/etc/kubernetes/manifests/scheduler/config-19.yaml_
+        ```
+        apiVersion: kubescheduler.config.k8s.io/v1beta1
+        kind: KubeSchedulerConfiguration
+        extenders:
+          - urlPrefix: "http://127.0.0.1:8889"
+            filterVerb: filter
+            prioritizeVerb: prioritize
+            weight: 1
+            enableHTTPS: false
+            nodeCacheCapable: false
+            ignorable: true
+            httpTimeout: 15s
+        leaderElection:
+          leaderElect: true
+        clientConnection:
+          kubeconfig: /etc/kubernetes/scheduler.conf
+        ```
+        *  Add the following sections to the _/etc/kubernetes/manifests/kube-scheduler.yaml_ configuration file
+            * Volume
+            ```
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/manifests/scheduler/config-19.yaml
+                type: File
+              name: scheduler-config-19
+            ```
+            * Volume mount
+            ```
+            volumeMounts:
+            - mountPath: /etc/kubernetes/manifests/scheduler/config-19.yaml
+              name: scheduler-config-19
+              readOnly: true
+            ```
+            * Command parameter
+            ```
+            spec:
+              containers:
+              - command:
+               - kube-scheduler
+               ...
+               - --config=/etc/kubernetes/manifests/scheduler/config-19.yaml
+            ```
 * RKE2
     
 * OpenShift

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -1,0 +1,13 @@
+Manual Kubernetes Scheduler Configuration
+---------------------
+To make CSI work correctly we maintain Kubernetes scheduler extender and scheduler extender patcher components.
+If your Kubernetes distributive is not in the list of supported or you have third party scheduler extender deployed the
+following manual steps are required
+* Vanilla Kubernetes
+    * Version 1.18 and below
+    * Version 1.19 and above
+* RKE2
+    
+* OpenShift
+
+* Other

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -4,8 +4,8 @@ To make CSI work correctly we maintain Kubernetes scheduler extender and schedul
 If your Kubernetes distributive is not in the list of supported or you have third party scheduler extender deployed the
 following manual steps are required
 * Vanilla Kubernetes
-    * If you have third party scheduler extender deployed just add the following sections to your configuration file
-    ```
+    * If you have third party scheduler extender deployed add the following sections to your configuration file
+    ```yaml
     extenders:
     ...
       - urlPrefix: "http://127.0.0.1:8889"
@@ -19,7 +19,7 @@ following manual steps are required
     ```
     * To manually patch version 1.18 and below
         * Create configuration policy file _/etc/kubernetes/manifests/scheduler/policy.yaml_
-        ```
+        ```yaml
         apiVersion: v1
         kind: Policy
         extenders:
@@ -33,7 +33,7 @@ following manual steps are required
             httpTimeout: 15000000000
         ```
         * Create configuration file _/etc/kubernetes/manifests/scheduler/config.yaml_
-        ```
+        ```yaml
         apiVersion: kubescheduler.config.k8s.io/v1alpha1
         kind: KubeSchedulerConfiguration
         schedulerName: default-scheduler
@@ -48,7 +48,7 @@ following manual steps are required
         ```
         *  Add the following sections to the _/etc/kubernetes/manifests/kube-scheduler.yaml_ configuration file
             * Volumes
-            ```
+            ```yaml
             volumes:
             - hostPath:
                 path: /etc/kubernetes/manifests/scheduler/config.yaml
@@ -60,7 +60,7 @@ following manual steps are required
               name: scheduler-policy
             ```
             * Volume mounts
-            ```
+            ```yaml
             volumeMounts:
             - mountPath: /etc/kubernetes/manifests/scheduler/config.yaml
               name: scheduler-config
@@ -70,7 +70,7 @@ following manual steps are required
               readOnly: true
             ```
             * Command parameter
-            ```
+            ```yaml
             spec:
               containers:
               - command:
@@ -80,7 +80,7 @@ following manual steps are required
             ```
     * To manually patch version 1.19 and above
         * Create configuration file _/etc/kubernetes/manifests/scheduler/config-19.yaml_
-        ```
+        ```yaml
         apiVersion: kubescheduler.config.k8s.io/v1beta1
         kind: KubeSchedulerConfiguration
         extenders:
@@ -99,7 +99,7 @@ following manual steps are required
         ```
         *  Add the following sections to the _/etc/kubernetes/manifests/kube-scheduler.yaml_ configuration file
             * Volume
-            ```
+            ```yaml
             volumes:
             - hostPath:
                 path: /etc/kubernetes/manifests/scheduler/config-19.yaml
@@ -107,14 +107,14 @@ following manual steps are required
               name: scheduler-config-19
             ```
             * Volume mount
-            ```
+            ```yaml
             volumeMounts:
             - mountPath: /etc/kubernetes/manifests/scheduler/config-19.yaml
               name: scheduler-config-19
               readOnly: true
             ```
             * Command parameter
-            ```
+            ```yaml
             spec:
               containers:
               - command:
@@ -126,11 +126,44 @@ following manual steps are required
     * Follow instructions for vanilla Kubernetes, but use the following path to the scheduler configuration file `/var/lib/rancher/rke2/agent/pod-manifests/`
     
 * OpenShift
-    * _TBD_
+    * If you have third party scheduler extender deployed add the following section to the _scheduler-policy_ config map in _openshift-config_ namespace
+    ```json
+    {
+      "urlPrefix": "http://127.0.0.1:8889",
+      "filterVerb": "filter",
+      "prioritizeVerb": "prioritize",
+      "weight": 1,
+      "enableHttps": false,
+      "nodeCacheCapable": false,
+      "ignorable": true
+    }
+    ```
+    * Create _policy.cfg_ file with following content:
+    ```json
+    {
+      "kind" : "Policy",
+      "apiVersion" : "v1",
+      "extenders": [
+        {
+            "urlPrefix": "http://127.0.0.1:8889",
+            "filterVerb": "filter",
+            "prioritizeVerb": "prioritize",
+            "weight": 1,
+            "enableHttps": false,
+            "nodeCacheCapable": false,
+            "ignorable": true
+        }
+      ]
+    }
+    ```
+    * Create _scheduler-policy_ config map in _openshift-config_ namespace:
+    ```shell script
+    oc create configmap -n openshift-config --from-file=policy.cfg scheduler-policy
+    ```
 
 * Other
     * Follow instructions provided by vendor. Use the following parameters:
-    ```
+    ```yaml
     extenders:
     ...
       - urlPrefix: "http://127.0.0.1:8889"

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -124,10 +124,12 @@ pods to restart after configuration change.
                - --config=/etc/kubernetes/manifests/scheduler/config-19.yaml
             ```
 * RKE2
-    * Follow instructions for vanilla Kubernetes, but use the following path to the scheduler configuration file `/var/lib/rancher/rke2/agent/pod-manifests/`
+    * Follow instructions for vanilla Kubernetes, but use the following path to the scheduler configuration file
+    `/var/lib/rancher/rke2/agent/pod-manifests/`
     
 * OpenShift
-    * If you have third party scheduler extender deployed add the following section to the _scheduler-policy_ config map in _openshift-config_ namespace
+    * If you have third party scheduler extender deployed add the following section to the config map specified in the
+    cluster custom resource of scheduler CRD `oc describe scheduler cluster`
     ```json
     {
       "urlPrefix": "http://127.0.0.1:8889",
@@ -160,6 +162,10 @@ pods to restart after configuration change.
     * Create _scheduler-policy_ config map in _openshift-config_ namespace:
     ```shell script
     oc create configmap -n openshift-config --from-file=policy.cfg scheduler-policy
+    ```
+    * Patch scheduler
+    ```shell script
+    oc patch scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"scheduler-policy"}}}' --type=merge
     ```
 
 * Other

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -165,7 +165,7 @@ pods to restart after configuration change.
     ```
     * Patch scheduler
     ```shell script
-    oc patch scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"scheduler-policy"}}}' --type=merge
+    oc patch scheduler cluster -p '{"spec":{"policy":{"name":"scheduler-policy"}}}' --type=merge
     ```
 
 * Other

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -34,19 +34,18 @@ following manual steps are required
         ```
         * Create configuration file _/etc/kubernetes/manifests/scheduler/config.yaml_
         ```
-         /etc/kubernetes/manifests/scheduler/config.yaml
-           apiVersion: kubescheduler.config.k8s.io/v1alpha1
-           kind: KubeSchedulerConfiguration
-           schedulerName: default-scheduler
-           algorithmSource:
-             policy:
-               file:
-                 path: /etc/kubernetes/manifests/scheduler/policy.yaml
-           leaderElection:
-             leaderElect: true
-           clientConnection:
-             kubeconfig: /etc/kubernetes/scheduler.conf
-         ```
+        apiVersion: kubescheduler.config.k8s.io/v1alpha1
+        kind: KubeSchedulerConfiguration
+        schedulerName: default-scheduler
+        algorithmSource:
+          policy:
+            file:
+              path: /etc/kubernetes/manifests/scheduler/policy.yaml
+        leaderElection:
+          leaderElect: true
+        clientConnection:
+          kubeconfig: /etc/kubernetes/scheduler.conf
+        ```
         *  Add the following sections to the _/etc/kubernetes/manifests/kube-scheduler.yaml_ configuration file
             * Volumes
             ```

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -4,8 +4,82 @@ To make CSI work correctly we maintain Kubernetes scheduler extender and schedul
 If your Kubernetes distributive is not in the list of supported or you have third party scheduler extender deployed the
 following manual steps are required
 * Vanilla Kubernetes
-    * Version 1.18 and below
-    * Version 1.19 and above
+    * If you have third party scheduler extender deployed just add the following sections to your configuration file
+    ```
+    extenders:
+    ...
+      - urlPrefix: "http://127.0.0.1:8889"
+        filterVerb: filter
+        prioritizeVerb: prioritize
+        weight: 1
+        enableHTTPS: false
+        nodeCacheCapable: false
+        ignorable: true
+        httpTimeout: 15s
+    ```
+    * To manually patch version 1.18 and below
+        * Create configuration policy file _/etc/kubernetes/manifests/scheduler/policy.yaml_
+        ```
+        apiVersion: v1
+        kind: Policy
+        extenders:
+          - urlPrefix: "http://127.0.0.1:8889"
+            filterVerb: filter
+            prioritizeVerb: prioritize
+            weight: 1
+            enableHttps: false
+            nodeCacheCapable: false
+            ignorable: true
+            httpTimeout: 15000000000
+        ```
+        * Create configuration file _/etc/kubernetes/manifests/scheduler/config.yaml_
+        ```
+         /etc/kubernetes/manifests/scheduler/config.yaml
+           apiVersion: kubescheduler.config.k8s.io/v1alpha1
+           kind: KubeSchedulerConfiguration
+           schedulerName: default-scheduler
+           algorithmSource:
+             policy:
+               file:
+                 path: /etc/kubernetes/manifests/scheduler/policy.yaml
+           leaderElection:
+             leaderElect: true
+           clientConnection:
+             kubeconfig: /etc/kubernetes/scheduler.conf
+         ```
+        *  Add the following sections to the _/etc/kubernetes/manifests/kube-scheduler.yaml_ configuration file
+            * Volumes
+            ```
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/manifests/scheduler/config.yaml
+                type: File
+              name: scheduler-config
+            - hostPath:
+                path: /etc/kubernetes/manifests/scheduler/policy.yaml
+                type: File
+              name: scheduler-policy
+            ```
+            * Volume mounts
+            ```
+            volumeMounts:
+            - mountPath: /etc/kubernetes/manifests/scheduler/config.yaml
+              name: scheduler-config
+              readOnly: true
+            - mountPath: /etc/kubernetes/manifests/scheduler/policy.yaml
+              name: scheduler-policy
+              readOnly: true
+            ```
+            * Command parameter
+            ```
+            spec:
+              containers:
+              - command:
+               - kube-scheduler
+               ...
+               - --config=/etc/kubernetes/manifests/scheduler/config.yaml
+            ```
+    * To manually patch version 1.19 and above
         * Create configuration file _/etc/kubernetes/manifests/scheduler/config-19.yaml_
         ```
         apiVersion: kubescheduler.config.k8s.io/v1beta1

--- a/docs/MANUAL_SCHEDULER_CONFIGURATION.md
+++ b/docs/MANUAL_SCHEDULER_CONFIGURATION.md
@@ -123,7 +123,22 @@ following manual steps are required
                - --config=/etc/kubernetes/manifests/scheduler/config-19.yaml
             ```
 * RKE2
+    * Follow instructions for vanilla Kubernetes, but use the following path to the scheduler configuration file `/var/lib/rancher/rke2/agent/pod-manifests/`
     
 * OpenShift
+    * _TBD_
 
 * Other
+    * Follow instructions provided by vendor. Use the following parameters:
+    ```
+    extenders:
+    ...
+      - urlPrefix: "http://127.0.0.1:8889"
+        filterVerb: filter
+        prioritizeVerb: prioritize
+        weight: 1
+        enableHTTPS: false
+        nodeCacheCapable: false
+        ignorable: true
+        httpTimeout: 15s
+    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,60 @@
 [![PR validation](https://github.com/dell/csi-baremetal-operator/actions/workflows/pr.yml/badge.svg)](https://github.com/dell/csi-baremetal-operator/actions/workflows/pr.yml)
 [![codecov](https://codecov.io/gh/dell/csi-baremetal-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/dell/csi-baremetal-operator)
 
-# csi-baremetal-operator
+Bare-metal CSI Operator
+=====================
 
 Kubernetes Operator to deploy and manage lifecycle of [Bare-Metal CSI Driver](https://github.com/dell/csi-baremetal)
+
+Installation process
+---------------------
+
+* Add helm repository
+```
+helm repo add csi https://dell.github.io/csi-baremetal-operator
+helm repo update
+helm search repo csi --devel -l
+```
+* Install CSI Operator
+```
+helm install csi-baremetal-operator csi/csi-baremetal-operator --devel 
+```
+* Install CSI     
+    * Vanilla Kubernetes
+        ```
+        helm install csi-baremetal csi/csi-baremetal-deployment --devel 
+        ```
+    * RKE2
+        ```
+        helm install csi-baremetal csi/csi-baremetal-deployment --devel --set platform=rke
+        ```
+    * OpenShift
+      ```
+      helm install csi-baremetal csi/csi-baremetal-deployment --devel --set platform=openshift
+      ```
+    * Not supported platform or/and system with third party Kubernetes scheduler extender - refer [documentation](MANUAL_SCHEDULER_CONFIGURATION.md) for manual patching of Kubernetes scheduler configuration
+      ```
+      helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=false
+      ```
+        
+Uninstallation process
+---------------------
+* Delete custom resources
+```
+kubectl delete pvc --all
+kubectl delete volumes --all
+kubectl delete lvgs --all
+kubectl delete csibmnodes --all
+```
+* Delete helm releases
+```
+helm delete csi-baremetal
+helm delete csi-baremetal-operator
+```
+* Delete custom resource definitions
+```
+kubectl delete crd deployments.csi-baremetal.dell.com availablecapacities.csi-baremetal.dell.com availablecapacityreservations.csi-baremetal.dell.com logicalvolumegroups.csi-baremetal.dell.com volumes.csi-baremetal.dell.com drives.csi-baremetal.dell.com nodes.csi-baremetal.dell.com
+```
+
+
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ helm install csi-baremetal-operator csi/csi-baremetal-operator --devel
       ```
       helm install csi-baremetal csi/csi-baremetal-deployment --devel --set platform=openshift
       ```
-    * Not supported platform or/and system with third party Kubernetes scheduler extender - refer [documentation](MANUAL_SCHEDULER_CONFIGURATION.md) for manual patching of Kubernetes scheduler configuration
+    * Not supported platform or system with third party Kubernetes scheduler extender - refer [documentation](MANUAL_SCHEDULER_CONFIGURATION.md) for manual patching of Kubernetes scheduler configuration
       ```
       helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=false
       ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,19 +22,19 @@ helm install csi-baremetal-operator csi/csi-baremetal-operator --devel
 * Install CSI     
     * Vanilla Kubernetes
         ```
-        helm install csi-baremetal csi/csi-baremetal-deployment --devel 
+        helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=true
         ```
     * RKE2
         ```
-        helm install csi-baremetal csi/csi-baremetal-deployment --devel --set platform=rke
+        helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=true --set platform=rke
         ```
     * OpenShift
       ```
-      helm install csi-baremetal csi/csi-baremetal-deployment --devel --set platform=openshift
+      helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=true --set platform=openshift
       ```
     * Not supported platform or system with third party Kubernetes scheduler extender - refer [documentation](MANUAL_SCHEDULER_CONFIGURATION.md) for manual patching of Kubernetes scheduler configuration
       ```
-      helm install csi-baremetal csi/csi-baremetal-deployment --devel --set scheduler.patcher.enable=false
+      helm install csi-baremetal csi/csi-baremetal-deployment --devel
       ```
         
 Uninstallation process

--- a/pkg/constant/platforms.go
+++ b/pkg/constant/platforms.go
@@ -1,0 +1,10 @@
+package constant
+
+const (
+	// PlatformVanilla - vanilla platform key
+	PlatformVanilla = "vanilla"
+	// PlatformRKE - RKE platform key
+	PlatformRKE = "rke"
+	// PlatformOpenShift - openshift platform key
+	PlatformOpenShift = "openshift"
+)

--- a/pkg/patcher/patcher_configuration.go
+++ b/pkg/patcher/patcher_configuration.go
@@ -6,16 +6,10 @@ import (
 
 	csibaremetalv1 "github.com/dell/csi-baremetal-operator/api/v1"
 	"github.com/dell/csi-baremetal-operator/api/v1/components"
+	"github.com/dell/csi-baremetal-operator/pkg/constant"
 )
 
 const (
-	// PlatformVanilla - vanilla platform key
-	PlatformVanilla = "vanilla"
-	// PlatformRKE - RKE platform key
-	PlatformRKE = "rke"
-	// PlatformOpenshift - openshift platform key
-	PlatformOpenshift = "openshift"
-
 	rke2ManifestsFolder    = "/var/lib/rancher/rke2/agent/pod-manifests"
 	vanillaManifestsFolder = "/etc/kubernetes/manifests"
 
@@ -37,9 +31,9 @@ const (
 func newPatcherConfiguration(csi *csibaremetalv1.Deployment) (*patcherConfiguration, error) {
 	var config patcherConfiguration
 	switch csi.Spec.Platform {
-	case PlatformVanilla:
+	case constant.PlatformVanilla:
 		config = patcherConfiguration{
-			platform:        PlatformVanilla,
+			platform:        constant.PlatformVanilla,
 			targetConfig:    path.Join(vanillaManifestsFolder, configPath),
 			targetPolicy:    path.Join(vanillaManifestsFolder, policyPath),
 			targetConfig19:  path.Join(vanillaManifestsFolder, config19Path),
@@ -47,9 +41,9 @@ func newPatcherConfiguration(csi *csibaremetalv1.Deployment) (*patcherConfigurat
 			manifestsFolder: vanillaManifestsFolder,
 			kubeconfig:      vanillaKubeconfig,
 		}
-	case PlatformRKE:
+	case constant.PlatformRKE:
 		config = patcherConfiguration{
-			platform:        PlatformRKE,
+			platform:        constant.PlatformRKE,
 			targetConfig:    path.Join(rke2ManifestsFolder, configPath),
 			targetPolicy:    path.Join(rke2ManifestsFolder, policyPath),
 			targetConfig19:  path.Join(rke2ManifestsFolder, config19Path),

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	csibaremetalv1 "github.com/dell/csi-baremetal-operator/api/v1"
+	"github.com/dell/csi-baremetal-operator/pkg/constant"
 )
 
 // SchedulerPatcher performs pacthing procedure depends on platform
@@ -24,9 +25,9 @@ func (p *SchedulerPatcher) Update(ctx context.Context, csi *csibaremetalv1.Deplo
 	var err error
 
 	switch csi.Spec.Platform {
-	case PlatformOpenshift:
+	case constant.PlatformOpenShift:
 		err = p.patchOpenShift(ctx, csi)
-	case PlatformVanilla, PlatformRKE:
+	case constant.PlatformVanilla, constant.PlatformRKE:
 		err = p.updateVanilla(ctx, csi, scheme)
 	default:
 		p.Logger.Info("Platform is unavailable or not set. Patching disabled")
@@ -42,7 +43,7 @@ func (p *SchedulerPatcher) Update(ctx context.Context, csi *csibaremetalv1.Deplo
 // Uninstall unpatch Openshift Scheduler
 func (p *SchedulerPatcher) Uninstall(ctx context.Context, csi *csibaremetalv1.Deployment) error {
 	switch csi.Spec.Platform {
-	case PlatformOpenshift:
+	case constant.PlatformOpenShift:
 		return p.unPatchOpenShift(ctx)
 	default:
 		return nil

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -23,6 +23,7 @@ type SchedulerPatcher struct {
 // patches Kube-Scheduler on Openshift
 func (p *SchedulerPatcher) Update(ctx context.Context, csi *csibaremetalv1.Deployment, scheme *runtime.Scheme) error {
 	if !IsPatchingEnabled(csi) {
+		// todo change severity to warning once https://github.com/dell/csi-baremetal/issues/371 is addressed
 		p.Logger.Info("Kubernetes scheduler configuration patching not enabled. Please update configuration manually")
 		return nil
 	}

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -57,7 +57,6 @@ func (n *SchedulerExtender) createExtenderDaemonSet(csi *csibaremetalv1.Deployme
 	)
 
 	if isPatchingEnabled {
-		n.Logger.Info("Kubernetes scheduler configuration patching enabled")
 		volumes = append(volumes, corev1.Volume{
 			Name: patcher.ExtenderConfigMapName,
 			VolumeSource: corev1.VolumeSource{
@@ -67,9 +66,6 @@ func (n *SchedulerExtender) createExtenderDaemonSet(csi *csibaremetalv1.Deployme
 					Optional:             pointer.BoolPtr(true),
 				},
 			}})
-	} else {
-		// todo make it warning once https://github.com/dell/csi-baremetal/issues/351 is implemented
-		n.Logger.Info("Kubernetes scheduler configuration patching not enabled. Please update configuration manually")
 	}
 
 	return &v1.DaemonSet{


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#500

Changes to work with third party k8s scheduler extender:
1. Use flag `scheduler.patcher.enable` in addition to platform
2. Add documentation for manual patching

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [x] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Without patcher:
```
$ helm install csi-baremetal charts/csi-baremetal-deployment ...
$ kubectl get pods
NAME                                             READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-f9b7f4c66-4t8v6         4/4     Running   0          11m
csi-baremetal-node-controller-5648569f77-cwlks   1/1     Running   0          11m
csi-baremetal-node-kernel-5.4-bqs8k              4/4     Running   0          11m
csi-baremetal-node-kernel-5.4-k6r9q              4/4     Running   0          11m
csi-baremetal-node-kernel-5.4-kth4n              4/4     Running   0          11m
csi-baremetal-operator-6fcf7c865b-6qkng          1/1     Running   0          52m
csi-baremetal-se-66t9g                           1/1     Running   0          11m
```
With patcher:
```
$ helm install csi-baremetal charts/csi-baremetal-deployment --set scheduler.patcher.enable=true ...
$ kubectl get pods
NAME                                             READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-f9b7f4c66-7zd5w         4/4     Running   0          76s
csi-baremetal-node-controller-5648569f77-lpfqh   1/1     Running   0          77s
csi-baremetal-node-kernel-5.4-j5ml6              4/4     Running   0          76s
csi-baremetal-node-kernel-5.4-s9kdw              4/4     Running   0          76s
csi-baremetal-node-kernel-5.4-t7sr6              4/4     Running   0          76s
csi-baremetal-operator-6fcf7c865b-6qkng          1/1     Running   0          55m
csi-baremetal-se-fkczr                           1/1     Running   0          76s
csi-baremetal-se-patcher-crw9z                   1/1     Running   0          76s
```
Test manual instructions on k8s 1.18, 1.19, rke2 and openshift