### PR TITLE
[ISSUE-515] Rename node operator image

### DIFF
--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -97,7 +97,7 @@ spec:
   nodeController:
     enable: {{ .Values.nodeController.enable }}
     image:
-      name: csi-baremetal-operator
+      name: csi-baremetal-node-controller
       tag: {{ .Values.nodeController.image.tag | default .Values.image.tag }}
     log:
       format: {{ .Values.nodeController.log.format }}


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#515

Rename node operator image to get rid of name conflict with csi operator image

## PR checklist
- [ ] Add link to the issue
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
In progress
