### PR TITLE
[ISSUE-535] Remove outdated ACRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dell/csi-baremetal-operator/controllers"
 	"github.com/dell/csi-baremetal-operator/pkg"
+	"github.com/dell/csi-baremetal-operator/pkg/acrvalidator"
 	"github.com/dell/csi-baremetal-operator/pkg/common"
 	// +kubebuilder:scaffold:imports
 )
@@ -71,6 +72,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	acrvalidator.LauncACRValidation(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("acr_validator"))
 
 	ctx := context.Background()
 

--- a/pkg/acrvalidator/acr_validator.go
+++ b/pkg/acrvalidator/acr_validator.go
@@ -19,10 +19,12 @@ const (
 	validationTimeout = 60 * time.Second
 )
 
-// This package implements a watcher, which has to check
+// acrvalidator package implements a watcher, which has to check
 // all existing ACRs and remove ones, if they are outdated
-// (pods for these ACRs were removed). It's the workaround
-// until we use scheduler-extender
+// (pods for these ACRs were removed). Stacked volumes may
+// lead to races, if they are in RESERVED state (block other
+// reservations) or new created pods have the same name.
+// It's the workaround until we use scheduler-extender
 
 // ACRValidator is the watcher to remove outdated ACRs
 type ACRValidator struct {

--- a/pkg/acrvalidator/acr_validator.go
+++ b/pkg/acrvalidator/acr_validator.go
@@ -1,0 +1,90 @@
+package acrvalidator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	acrcrd "github.com/dell/csi-baremetal/api/v1/acreservationcrd"
+)
+
+const (
+	ctxTimeout        = 30 * time.Second
+	validationTimeout = 60 * time.Second
+)
+
+// This package implements a watcher, which has to check
+// all existing ACRs and remove ones, if they are outdated
+// (pods for these ACRs were removed). It's the workaround
+// until we use scheduler-extender
+
+// ACRValidator is the watcher to remove outdated ACRs
+type ACRValidator struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+// LauncACRValidation creates an instance of ACRValidator and
+// start the infinite loop to validate ACRs by timeout
+func LauncACRValidation(client client.Client, log logr.Logger) {
+	validator := &ACRValidator{
+		Client: client,
+		Log:    log,
+	}
+
+	go func() {
+		for {
+			time.Sleep(validationTimeout)
+			validator.validateACRs()
+		}
+	}()
+}
+
+func (v *ACRValidator) validateACRs() {
+	ctx, cancelFn := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancelFn()
+
+	acrs := &acrcrd.AvailableCapacityReservationList{}
+	err := v.Client.List(ctx, acrs)
+	if err != nil {
+		v.Log.Error(err, fmt.Sprintf("Failed to get ACR List: %s", err.Error()))
+		return
+	}
+
+	for i, acr := range acrs.Items {
+		ns, podName := getPodName(&acrs.Items[i])
+
+		pod := &corev1.Pod{}
+		err := v.Client.Get(ctx, client.ObjectKey{Name: podName, Namespace: ns}, pod)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			v.Log.Error(err, fmt.Sprintf("Failed to get pod %s in %s namespace: %s", podName, ns, err.Error()))
+			continue
+		}
+
+		if k8serrors.IsNotFound(err) {
+			// need to make it warning after log library changed
+			v.Log.Info(fmt.Sprintf("ACR %s is no longer actual. Pod %s in %s ns was removed. Try to delete", acr.GetName(), podName, ns))
+			err := v.Client.Delete(ctx, &acrs.Items[i])
+			if err != nil {
+				v.Log.Error(err, fmt.Sprintf("Failed to delete ACR %s: %s", acr.GetName(), err.Error()))
+			} else {
+				v.Log.Info(fmt.Sprintf("ACR %s was successfully deleted", acr.GetName()))
+			}
+		}
+	}
+}
+
+// getPodName returns namespace and pod names for passed acr
+// must be synced with https://github.com/dell/csi-baremetal/blob/4c0c38da3cdb57a214e63c8ef1373bff8841db49/pkg/scheduler/extender/extender.go#L356
+func getPodName(acr *acrcrd.AvailableCapacityReservation) (string, string) {
+	namespace := acr.Spec.Namespace
+	pod := strings.Replace(acr.GetName(), namespace+"-", "", 1)
+
+	return namespace, pod
+}

--- a/pkg/acrvalidator/acr_validator_test.go
+++ b/pkg/acrvalidator/acr_validator_test.go
@@ -2,9 +2,8 @@ package acrvalidator
 
 import (
 	"context"
-	"github.com/dell/csi-baremetal-operator/pkg/common"
-	api "github.com/dell/csi-baremetal/api/generated/v1"
-	acrcrd "github.com/dell/csi-baremetal/api/v1/acreservationcrd"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -12,7 +11,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
+
+	"github.com/dell/csi-baremetal-operator/pkg/common"
+
+	api "github.com/dell/csi-baremetal/api/generated/v1"
+	acrcrd "github.com/dell/csi-baremetal/api/v1/acreservationcrd"
 )
 
 const (

--- a/pkg/acrvalidator/acr_validator_test.go
+++ b/pkg/acrvalidator/acr_validator_test.go
@@ -1,0 +1,106 @@
+package acrvalidator
+
+import (
+	"context"
+	"github.com/dell/csi-baremetal-operator/pkg/common"
+	api "github.com/dell/csi-baremetal/api/generated/v1"
+	acrcrd "github.com/dell/csi-baremetal/api/v1/acreservationcrd"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+const (
+	testNS = "ns"
+)
+
+var (
+	ctx = context.Background()
+)
+
+func Test_validateACRs(t *testing.T) {
+	t.Run("Should not delete ACR if pod exists", func(t *testing.T) {
+		var (
+			pod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: testNS,
+				},
+			}
+			acr = acrcrd.AvailableCapacityReservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: getReservationName(&pod),
+				},
+				Spec: api.AvailableCapacityReservation{
+					Namespace: testNS,
+				},
+			}
+			updatedPod = corev1.Pod{}
+			updatedACR = acrcrd.AvailableCapacityReservation{}
+		)
+
+		cv := setupACRValidator(&pod, &acr)
+		cv.validateACRs()
+
+		err := cv.Client.Get(ctx, client.ObjectKey{Name: pod.Name, Namespace: pod.Namespace}, &updatedPod)
+		assert.Nil(t, err)
+		assert.NotNil(t, updatedPod)
+
+		err = cv.Client.Get(ctx, client.ObjectKey{Name: acr.Name, Namespace: ""}, &updatedACR)
+		assert.Nil(t, err)
+		assert.NotNil(t, updatedACR)
+	})
+
+	t.Run("Should delete ACR if pod removed", func(t *testing.T) {
+		var (
+			pod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: testNS,
+				},
+			}
+			acr = acrcrd.AvailableCapacityReservation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: getReservationName(&pod),
+				},
+				Spec: api.AvailableCapacityReservation{
+					Namespace: testNS,
+				},
+			}
+			updatedACR = acrcrd.AvailableCapacityReservation{}
+		)
+
+		cv := setupACRValidator(&acr)
+		cv.validateACRs()
+
+		err := cv.Client.Get(ctx, client.ObjectKey{Name: acr.Name, Namespace: ""}, &updatedACR)
+		assert.NotNil(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+}
+
+func setupACRValidator(objects ...client.Object) *ACRValidator {
+	scheme, _ := common.PrepareScheme()
+	builder := fake.ClientBuilder{}
+	builderWithScheme := builder.WithScheme(scheme)
+	client := builderWithScheme.WithObjects(objects...).Build()
+
+	return &ACRValidator{
+		Client: client,
+		Log:    ctrl.Log.WithName("ACRValidatorTest"),
+	}
+}
+
+func getReservationName(pod *corev1.Pod) string {
+	namespace := pod.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	return namespace + "-" + pod.Name
+}


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#535

- Add the watcher to check and remove outdated ACRs
- Start it the main as infinite goroutine 

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [x] New unit tests added
- [x] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
user@user-vm ~/g/s/g/dell> ka csi-baremetal/test/app/testlvg/2.yaml
statefulset.apps/web2 created
user@user-vm ~/g/s/g/dell> kg acr
NAME             NAMESPACE   STATUS
default-web2-0   default     REJECTED
default-web2-1   default     REJECTED
default-web2-2   default     REJECTED
user@user-vm ~/g/s/g/dell> kdl -f csi-baremetal/test/app/testlvg/2.yaml
statefulset.apps "web2" deleted
user@user-vm ~/g/s/g/dell> kdl pvc -A --all
persistentvolumeclaim "www-web2-0" deleted
persistentvolumeclaim "www-web2-1" deleted
persistentvolumeclaim "www-web2-2" deleted
persistentvolumeclaim "www1-web2-0" deleted
persistentvolumeclaim "www1-web2-1" deleted
persistentvolumeclaim "www1-web2-2" deleted
user@user-vm ~/g/s/g/dell> kg acr
No resources found
```
