### PR TITLE
[ISSUE-598] Add SC for NVME raw-partitioned mode

### DIFF
--- a/charts/csi-baremetal-deployment/templates/storageclass/nvme-raw-part-sc.yaml
+++ b/charts/csi-baremetal-deployment/templates/storageclass/nvme-raw-part-sc.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.name }}-nvme
+# CSI driver name
+provisioner: csi-baremetal
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  storageType: NVME
+  fsType: xfs
+  isPartitioned: true

--- a/charts/csi-baremetal-deployment/templates/storageclass/nvme-raw-part-sc.yaml
+++ b/charts/csi-baremetal-deployment/templates/storageclass/nvme-raw-part-sc.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.storageClass.name }}-nvme
+  name: {{ .Values.storageClass.name }}-nvme-raw-part
 # CSI driver name
 provisioner: csi-baremetal
 reclaimPolicy: Delete
@@ -9,4 +9,4 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   storageType: NVME
   fsType: xfs
-  isPartitioned: true
+  isPartitioned: "true"


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#598

Related changes with https://github.com/dell/csi-baremetal/pull/599

## PR checklist
- [x] Add link to the issue
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
user@user-vm ~/g/s/g/dell> kd volume
Name:         pvc-332271f9-7050-4ffc-a58b-bcfe49e55648
Namespace:    default
Labels:       app=nginx
              app.kubernetes.io/name=nginx
Annotations:  <none>
API Version:  csi-baremetal.dell.com/v1
Kind:         Volume
Metadata:
  Creation Timestamp:  2021-11-09T08:30:18Z
  Finalizers:
    dell.emc.csi/volume-cleanup
  Generation:  4
  Managed Fields:
    API Version:  csi-baremetal.dell.com/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          .:
          f:app:
          f:app.kubernetes.io/name:
      f:spec:
        .:
        f:Health:
        f:Id:
        f:Location:
        f:LocationType:
        f:Mode:
        f:NodeId:
        f:OperationalStatus:
        f:Size:
        f:StorageClass:
        f:Usage:
    Manager:      controller
    Operation:    Update
    Time:         2021-11-09T08:30:18Z
    API Version:  csi-baremetal.dell.com/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"dell.emc.csi/volume-cleanup":
      f:spec:
        f:CSIStatus:
        f:Owners:
    Manager:         node
    Operation:       Update
    Time:            2021-11-09T08:30:27Z
  Resource Version:  5449692
  Self Link:         /apis/csi-baremetal.dell.com/v1/namespaces/default/volumes/pvc-332271f9-7050-4ffc-a58b-bcfe49e55648
  UID:               ca923108-6f57-458a-a2b9-93fb47d78801
Spec:
  CSI Status:          PUBLISHED
  Health:              GOOD
  Id:                  pvc-332271f9-7050-4ffc-a58b-bcfe49e55648
  Location:            d3e805f6-8f2f-4f75-a250-d91a19405693
  Location Type:       DRIVE
  Mode:                RAW_PART
  Node Id:             0ef1752f-c5fc-4e74-98fc-0e2830fd56bb
  Operational Status:  OPERATIVE
  Owners:
    UNKNOWN
  Size:           105906176
  Storage Class:  NVME
  Usage:          IN_USE
Events:           <none>
user@user-vm ~/g/s/g/dell> kgo drive d3e805f6-8f2f-4f75-a250-d91a19405693
NAME                                   SIZE        TYPE   HEALTH   STATUS   USAGE    SYSTEM   PATH          SERIAL NUMBER       NODE                                   SLOT
d3e805f6-8f2f-4f75-a250-d91a19405693   105906176   NVME   GOOD     ONLINE   IN_USE            /dev/loop21   LOOPBACK133988504   0ef1752f-c5fc-4e74-98fc-0e2830fd56bb   
user@user-vm ~/g/s/g/dell> 
user@user-vm ~/g/s/g/dell> lsblk /dev/loop21
NAME       MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
loop21       7:21   0  101M  0 loop 
└─loop21p1 259:0    0  101M  0 part 
```
