### PR TITLE
[ISSUE-637] Support k8s 1.22 version for csi

### DIFF
--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -39,7 +39,11 @@ spec:
         csi-provisioner:
           image:
             name: csi-provisioner
+            {{- if semverCompare ">=1.22.0" .Capabilities.KubeVersion.Version }}
             tag: {{ .Values.driver.provisioner.image.tag }}
+            {{- else }}
+            tag: {{ .Values.driver.provisioner.image.deprecatedTag }}
+            {{- end }}
           resources:
             {{- include "setResources" .Values.driver.provisioner | indent 12 }}
         csi-resizer:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -77,7 +77,10 @@ driver:
   provisioner:
     image:
       # if you want to use topology feature (multiple PVCs per pod) you should use v1.2.2
-      tag: v1.6.0
+      tag: v3.0.0
+      # storage.k8s.io/v1beta1 CSINode object has been deprecated and was removed in the 1.22 release
+      # storage.k8s.io/v1 CSINode object introduced
+      deprecatedTag: v1.6.0
     resources:
       limits:
         cpu:


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#637

storage.k8s.io/v1beta1 CSINode object has been deprecated and was removed in the 1.22 release; storage.k8s.io/v1 CSINode object introduced
To support 1.22 version we should update image for csi-provisioner sidecar of csi-controller

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Testing details_
