### PR TITLE
[ISSUE-637] Support k8s 1.22 version for csi

### DIFF
--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -39,7 +39,11 @@ spec:
         csi-provisioner:
           image:
             name: csi-provisioner
+            {{- if semverCompare ">=1.22.0" .Capabilities.KubeVersion.Version }}
             tag: {{ .Values.driver.provisioner.image.tag }}
+            {{- else }}
+            tag: {{ .Values.driver.provisioner.image.deprecatedTag }}
+            {{- end }}
           resources:
             {{- include "setResources" .Values.driver.provisioner | indent 12 }}
         csi-resizer:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -77,7 +77,10 @@ driver:
   provisioner:
     image:
       # if you want to use topology feature (multiple PVCs per pod) you should use v1.2.2
-      tag: v1.6.0
+      tag: v3.0.0
+      # storage.k8s.io/v1beta1 CSINode object has been deprecated and was removed in the 1.22 release
+      # storage.k8s.io/v1 CSINode object introduced
+      deprecatedTag: v1.6.0
     resources:
       limits:
         cpu:


### PR DESCRIPTION
Signed-off-by: Nikita Mikhnenko <nikita_mikhnenko@dell.com>

## Purpose
### Issue dell/csi-baremetal#637

storage.k8s.io/v1beta1 CSINode object has been deprecated and was removed in the 1.22 release; storage.k8s.io/v1 CSINode object introduced
To support 1.22 version we should update image for csi-provisioner sidecar of csi-controller

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get nodes
NAME                 STATUS   ROLES                  AGE   VERSION
kind-control-plane   Ready    control-plane,master   31h   v1.22.4
kind-worker          Ready    <none>                 31h   v1.22.4
kind-worker2         Ready    <none>                 31h   v1.22.4
kind-worker3         Ready    <none>                 31h   v1.22.4
kind-worker4         Ready    <none>                 31h   v1.22.4
kind-worker5         Ready    <none>                 31h   v1.22.4
kind-worker6         Ready    <none>                 31h   v1.22.4

nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get po
NAME                                            READY   STATUS    RESTARTS      AGE
csi-baremetal-controller-58d6c9444b-bl2zx       4/4     Running   0             3m6s
csi-baremetal-node-84jql                        4/4     Running   1 (63s ago)   3m6s
csi-baremetal-node-8k5ph                        4/4     Running   1 (62s ago)   3m6s
csi-baremetal-node-controller-788d66879-9zqzx   1/1     Running   0             3m7s
csi-baremetal-node-g44ff                        4/4     Running   1 (64s ago)   3m6s
csi-baremetal-node-gdsxq                        4/4     Running   1 (60s ago)   3m6s
csi-baremetal-node-sw9mk                        4/4     Running   1 (61s ago)   3m7s
csi-baremetal-node-wnqm9                        4/4     Running   1 (64s ago)   3m6s
csi-baremetal-operator-57cf857b64-96vtt         1/1     Running   0             3m50s
csi-baremetal-se-gmt54                          1/1     Running   0             3m6s
csi-baremetal-se-patcher-bbt5v                  1/1     Running   0             3m6s

nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get po csi-baremetal-controller-58d6c9444b-bl2zx -oyaml | grep provisioner
    image: asdrepo.isus.emc.com:8099/csi-provisioner:v3.0.0
    name: csi-provisioner
    image: asdrepo.isus.emc.com:8099/csi-provisioner:v3.0.0
    name: csi-provisioner
```

Test statefulset:
```
nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get statefulset
NAME    READY   AGE
web-1   3/3     5m36s

nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS           REASON   AGE
pvc-791ea9fc-30c1-4564-a749-d5c20f15ac01   101Mi      RWO            Delete           Bound    default/www-web-1-1   csi-baremetal-sc-hdd            4m9s
pvc-7e4364ae-a11c-4542-b369-22804e72d213   101Mi      RWO            Delete           Bound    default/www-web-1-2   csi-baremetal-sc-hdd            2m40s
pvc-b7d43acd-be6e-48aa-8fd3-a3790327f80e   101Mi      RWO            Delete           Bound    default/www-web-1-0   csi-baremetal-sc-hdd
```