### PR TITLE
[ISSUE-637] Removing deprecated provisioner from charts

### DIFF
--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -39,11 +39,7 @@ spec:
         csi-provisioner:
           image:
             name: csi-provisioner
-            {{- if semverCompare ">=1.22.0" .Capabilities.KubeVersion.Version }}
             tag: {{ .Values.driver.provisioner.image.tag }}
-            {{- else }}
-            tag: {{ .Values.driver.provisioner.image.deprecatedTag }}
-            {{- end }}
           resources:
             {{- include "setResources" .Values.driver.provisioner | indent 12 }}
         csi-resizer:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -78,9 +78,6 @@ driver:
     image:
       # if you want to use topology feature (multiple PVCs per pod) you should use v1.2.2
       tag: v3.0.0
-      # storage.k8s.io/v1beta1 CSINode object has been deprecated and was removed in the 1.22 release
-      # storage.k8s.io/v1 CSINode object introduced
-      deprecatedTag: v1.6.0
     resources:
       limits:
         cpu:


### PR DESCRIPTION
Signed-off-by: Nikita Mikhnenko <nikita_mikhnenko@dell.com>

## Purpose

Issue dell/csi-baremetal#637
Currently csi-baremetal supports k8s versions: 1.18-1.22 and so there is no need to support deprecated provisioner in charts

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing

### Provisioner v3.0.0 support k8s 1.18 version in earlier:
```
nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get nodes
NAME                 STATUS   ROLES    AGE    VERSION
kind-control-plane   Ready    master   156m   v1.18.2
kind-worker          Ready    <none>   156m   v1.18.2
kind-worker2         Ready    <none>   156m   v1.18.2
kind-worker3         Ready    <none>   156m   v1.18.2
kind-worker4         Ready    <none>   156m   v1.18.2
kind-worker5         Ready    <none>   156m   v1.18.2
kind-worker6         Ready    <none>   156m   v1.18.2

mikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get po
NAME                                             READY   STATUS    RESTARTS   AGE
csi-baremetal-controller-59cc4d75d5-dsxgs        4/4     Running   0          10m
csi-baremetal-node-9lsww                         4/4     Running   0          10m
csi-baremetal-node-controller-7f7f66c88b-ct6kl   1/1     Running   0          10m
csi-baremetal-node-ph54v                         4/4     Running   0          10m
csi-baremetal-node-qzr4l                         4/4     Running   0          10m
csi-baremetal-node-vm7sf                         4/4     Running   0          10m
csi-baremetal-node-xmpdg                         4/4     Running   0          10m
csi-baremetal-node-zjh2n                         4/4     Running   0          10m
csi-baremetal-operator-69f9bccf89-gvq9b          1/1     Running   0          27m
csi-baremetal-se-patcher-dkdjf                   1/1     Running   0          10m
csi-baremetal-se-xd4th                           1/1     Running   0          10m

nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get po  csi-baremetal-controller-59cc4d75d5-dsxgs -oyaml | grep provisioner
    image: asdrepo.isus.emc.com:8099/csi-provisioner:v3.0.0
    name: csi-provisioner
    image: asdrepo.isus.emc.com:8099/csi-provisioner:v3.0.0
    name: csi-provisioner
```

Test statefulset:
```
nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get statefulset
NAME    READY   AGE
web-1   3/3     7m53s

nmikhnenko@dev-main:~/work/Dell/go/src/csi-baremetal$ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS           REASON   AGE
pvc-190f9172-548c-4828-9022-3d577d75424a   101Mi      RWO            Delete           Bound    default/www-web-1-2   csi-baremetal-sc-hdd            6m58s
pvc-94391a03-f733-4476-9804-e6b7d8182aae   101Mi      RWO            Delete           Bound    default/www-web-1-1   csi-baremetal-sc-hdd            7m26s
pvc-e51b08cf-c9f8-4886-8ac2-af2a3a2b0f0d   101Mi      RWO            Delete           Bound    default/www-web-1-0   csi-baremetal-sc-hdd            8m1s
```

