### PR TITLE
[ISSUE-712] Add component labels for CSI pods

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,4 @@
 # TODO: improve code coverage - https://github.com/dell/csi-baremetal/issues/658
 ignore:
   - "pkg/node/node_daemonset.go"
+  - "pkg/patcher/scheduler_patcher_vanilla.go"

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacities.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacities.yaml
@@ -42,10 +42,14 @@ spec:
         description: AvailableCapacity is the Schema for the availablecapacities API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
@@ -41,13 +41,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AvailableCapacityReservation is the Schema for the availablecapacitiereservations API
+        description: AvailableCapacityReservation is the Schema for the availablecapacitiereservations
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_drives.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_drives.yaml
@@ -67,10 +67,14 @@ spec:
         description: Drive is the Schema for the drives API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
@@ -52,10 +52,14 @@ spec:
         description: LogicalVolumeGroup is the Schema for the LVGs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_nodes.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_nodes.yaml
@@ -38,10 +38,14 @@ spec:
         description: Node is the Schema for the Node API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -50,7 +54,8 @@ spec:
               Addresses:
                 additionalProperties:
                   type: string
-                description: key - address type, value - address, align with NodeAddress struct from k8s.io/api/core/v1
+                description: key - address type, value - address, align with NodeAddress
+                  struct from k8s.io/api/core/v1
                 type: object
               UUID:
                 type: string

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_volumes.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_volumes.yaml
@@ -62,10 +62,14 @@ spec:
         description: Volume is the Schema for the volumes API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/charts/csi-baremetal-operator/templates/manager.yaml
+++ b/charts/csi-baremetal-operator/templates/manager.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     app: csi-baremetal
     app.kubernetes.io/name: csi-baremetal
-    component: csi-baremetal-operator
-    app.kubernetes.io/component: csi-baremetal-operator
 spec:
   selector:
     matchLabels:

--- a/charts/csi-baremetal-operator/templates/manager.yaml
+++ b/charts/csi-baremetal-operator/templates/manager.yaml
@@ -17,8 +17,8 @@ spec:
         name: {{ .Release.Name }}
         app: csi-baremetal
         app.kubernetes.io/name: csi-baremetal
-        component: csi-baremetal-operator
-        app.kubernetes.io/component: csi-baremetal-operator
+        component: operator
+        app.kubernetes.io/component: operator
         # release label used by fluentbit to make "release" folder
         release: {{ .Release.Name }}
     spec:

--- a/charts/csi-baremetal-operator/templates/manager.yaml
+++ b/charts/csi-baremetal-operator/templates/manager.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: csi-baremetal
     app.kubernetes.io/name: csi-baremetal
+    component: csi-baremetal-operator
+    app.kubernetes.io/component: csi-baremetal-operator
 spec:
   selector:
     matchLabels:
@@ -17,6 +19,8 @@ spec:
         name: {{ .Release.Name }}
         app: csi-baremetal
         app.kubernetes.io/name: csi-baremetal
+        component: csi-baremetal-operator
+        app.kubernetes.io/component: csi-baremetal-operator
         # release label used by fluentbit to make "release" folder
         release: {{ .Release.Name }}
     spec:

--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -286,6 +286,11 @@ func watchRole(c controller.Controller, cl client.Client, m rbac.Matcher, matchP
 			return []reconcile.Request{}
 		}
 
+		if len(deployments.Items) == 0 {
+			// if there are no deployments - then just skip reconcile
+			return []reconcile.Request{}
+		}
+
 		if role, ok = obj.(*rbacv1.Role); !ok {
 			log.Warnf("got invalid Object type at Role watcher, actual type: '%s'", reflect.TypeOf(obj))
 			return []reconcile.Request{}
@@ -328,6 +333,11 @@ func watchRoleBinding(c controller.Controller, cl client.Client, m rbac.Matcher,
 		err := cl.List(ctx, deployments)
 		if err != nil {
 			log.Error(err, "Failed to list csi deployments")
+			return []reconcile.Request{}
+		}
+
+		if len(deployments.Items) == 0 {
+			// if there are no deployments - then just skip reconcile
 			return []reconcile.Request{}
 		}
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -139,6 +139,8 @@ func PrepareScheme() (*runtime.Scheme, error) {
 // ConstructLabelMap creates the map contains pod labels
 func ConstructLabelMap(appName string) map[string]string {
 	labels := ConstructLabelAppMap()
+	labels[constant.ComponentLabelKey] = appName
+	labels[constant.ComponentLabelShortKey] = appName
 	labels[constant.SelectorKey] = appName
 	labels[constant.FluentbitLabelKey] = appName
 	return labels

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -137,10 +137,10 @@ func PrepareScheme() (*runtime.Scheme, error) {
 }
 
 // ConstructLabelMap creates the map contains pod labels
-func ConstructLabelMap(appName string) map[string]string {
+func ConstructLabelMap(appName, componentName string) map[string]string {
 	labels := ConstructLabelAppMap()
-	labels[constant.ComponentLabelKey] = appName
-	labels[constant.ComponentLabelShortKey] = appName
+	labels[constant.ComponentLabelKey] = componentName
+	labels[constant.ComponentLabelShortKey] = componentName
 	labels[constant.SelectorKey] = appName
 	labels[constant.FluentbitLabelKey] = appName
 	return labels

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -57,6 +57,10 @@ const (
 	AppLabelKey = "app.kubernetes.io/name"
 	// AppLabelShortKey matches CSI CRs with csi-baremetal app
 	AppLabelShortKey = "app"
+	// ComponentLabelKey matches CSI CRs with csi-baremetal component
+	ComponentLabelKey = "app.kubernetes.io/component"
+	// ComponentLabelShortKey matches CSI CRs with csi-baremetal component
+	ComponentLabelShortKey = "component"
 	// AppLabelValue matches CSI CRs with csi-baremetal app
 	AppLabelValue = CSIName
 

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -67,7 +67,7 @@ func createControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelMap(controllerName),
+			Labels:    common.ConstructLabelAppMap(),
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(replicasCount),

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -67,7 +67,7 @@ func createControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelAppMap(),
+			Labels:    common.ConstructLabelMap(controllerName),
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(replicasCount),

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -57,7 +57,7 @@ func (c *Controller) Update(ctx context.Context, csi *csibaremetalv1.Deployment,
 func createControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployment {
 	var (
 		selectors = common.ConstructSelectorMap(controllerName)
-		labels    = common.ConstructLabelMap(controllerName)
+		labels    = common.ConstructLabelMap(controllerName, controller)
 	)
 
 	selectors["role"] = controllerRoleKey

--- a/pkg/node/node_daemonset.go
+++ b/pkg/node/node_daemonset.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	nodeName                  = constant.CSIName + "-node"
+	node                      = "node"
+	nodeName                  = constant.CSIName + "-" + node
 	loopbackManagerImageName  = "loopbackmgr"
 	loopbackManagerConfigName = "loopback-config"
 
@@ -63,7 +64,7 @@ func createNodeDaemonSet(csi *csibaremetalv1.Deployment, platform *PlatformDescr
 				// labels and annotations
 				ObjectMeta: metav1.ObjectMeta{
 					// labels
-					Labels: common.ConstructLabelMap(nodeName),
+					Labels: common.ConstructLabelMap(nodeName, node),
 					// integration with monitoring
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",

--- a/pkg/node/node_daemonset.go
+++ b/pkg/node/node_daemonset.go
@@ -51,7 +51,7 @@ func createNodeDaemonSet(csi *csibaremetalv1.Deployment, platform *PlatformDescr
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      platform.DaemonsetName(nodeName),
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelAppMap(),
+			Labels:    common.ConstructLabelMap(nodeName),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector

--- a/pkg/node/node_daemonset.go
+++ b/pkg/node/node_daemonset.go
@@ -51,7 +51,7 @@ func createNodeDaemonSet(csi *csibaremetalv1.Deployment, platform *PlatformDescr
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      platform.DaemonsetName(nodeName),
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelMap(nodeName),
+			Labels:    common.ConstructLabelAppMap(),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector

--- a/pkg/node_controller.go
+++ b/pkg/node_controller.go
@@ -52,7 +52,7 @@ func createNodeControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployme
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeControllerName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructSelectorMap(nodeControllerName),
+			Labels:    common.ConstructLabelAppMap(),
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(ncReplicasCount),

--- a/pkg/node_controller.go
+++ b/pkg/node_controller.go
@@ -64,7 +64,7 @@ func createNodeControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployme
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					// labels
-					Labels: common.ConstructLabelMap(nodeControllerName),
+					Labels: common.ConstructLabelMap(nodeControllerName, nodeController),
 				},
 				Spec: corev1.PodSpec{
 					Containers:                    createNodeControllerContainers(csi),

--- a/pkg/node_controller.go
+++ b/pkg/node_controller.go
@@ -52,7 +52,7 @@ func createNodeControllerDeployment(csi *csibaremetalv1.Deployment) *v1.Deployme
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeControllerName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelAppMap(),
+			Labels:    common.ConstructSelectorMap(nodeControllerName),
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(ncReplicasCount),

--- a/pkg/patcher/scheduler_patcher_vanilla.go
+++ b/pkg/patcher/scheduler_patcher_vanilla.go
@@ -169,7 +169,7 @@ func (p patcherConfiguration) createPatcherDaemonSet() *v1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      patcherName,
 			Namespace: p.ns,
-			Labels:    common.ConstructSelectorMap(patcherName),
+			Labels:    common.ConstructLabelAppMap(),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector

--- a/pkg/patcher/scheduler_patcher_vanilla.go
+++ b/pkg/patcher/scheduler_patcher_vanilla.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	patcherName          = constant.CSIName + "-se-patcher"
+	patcher              = "se-patcher"
+	patcherName          = constant.CSIName + "-" + patcher
 	patcherContainerName = "schedulerpatcher"
 
 	kubernetesManifestsVolume = "kubernetes-manifests"
@@ -181,7 +182,7 @@ func (p patcherConfiguration) createPatcherDaemonSet() *v1.DaemonSet {
 				// labels and annotations
 				ObjectMeta: metav1.ObjectMeta{
 					// labels
-					Labels: common.ConstructLabelMap(patcherName),
+					Labels: common.ConstructLabelMap(patcherName, patcher),
 				},
 				Spec: corev1.PodSpec{
 					Containers:                    p.createPatcherContainers(),

--- a/pkg/patcher/scheduler_patcher_vanilla.go
+++ b/pkg/patcher/scheduler_patcher_vanilla.go
@@ -169,7 +169,7 @@ func (p patcherConfiguration) createPatcherDaemonSet() *v1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      patcherName,
 			Namespace: p.ns,
-			Labels:    common.ConstructLabelAppMap(),
+			Labels:    common.ConstructSelectorMap(patcherName),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -29,7 +29,8 @@ import (
 
 const (
 	extenderContainerName = "scheduler-extender"
-	extenderName          = constant.CSIName + "-se"
+	extender              = "se"
+	extenderName          = constant.CSIName + "-" + extender
 
 	extenderPort = 8889
 )
@@ -118,7 +119,7 @@ func (n *SchedulerExtender) createExtenderDaemonSet(csi *csibaremetalv1.Deployme
 				// labels and annotations
 				ObjectMeta: metav1.ObjectMeta{
 					// labels
-					Labels: common.ConstructLabelMap(extenderName),
+					Labels: common.ConstructLabelMap(extenderName, extender),
 					// integration with monitoring
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -106,7 +106,7 @@ func (n *SchedulerExtender) createExtenderDaemonSet(csi *csibaremetalv1.Deployme
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      extenderName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructLabelAppMap(),
+			Labels:    common.ConstructSelectorMap(extenderName),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -106,7 +106,7 @@ func (n *SchedulerExtender) createExtenderDaemonSet(csi *csibaremetalv1.Deployme
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      extenderName,
 			Namespace: csi.GetNamespace(),
-			Labels:    common.ConstructSelectorMap(extenderName),
+			Labels:    common.ConstructLabelAppMap(),
 		},
 		Spec: v1.DaemonSetSpec{
 			// selector


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#712

- Add full `app.kubernetes.io/component` and short `component` labels

## PR checklist
- [x] Add link to the issue
- [x] Choose Project
- [x] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
```
user@user-vm:~/go_projects/src/github.com/dell$ for podname in $(kubectl get pods | grep -v NAME | awk '{ print $1 }'); do echo $podname; kubectl describe pod $podname | grep component; done
csi-baremetal-controller-795f56d565-68srg
              app.kubernetes.io/component=controller
              component=controller
csi-baremetal-node-controller-959df6f67-r4rr8
              app.kubernetes.io/component=node-controller
              component=node-controller
csi-baremetal-node-kernel-5.4-jddms
              app.kubernetes.io/component=node
              component=node
csi-baremetal-node-kernel-5.4-z5r26
              app.kubernetes.io/component=node
              component=node
csi-baremetal-operator-7d7f947fc-dcpjq
              app.kubernetes.io/component=operator
              component=operator
csi-baremetal-se-patcher-2nj22
              app.kubernetes.io/component=se-patcher
              component=se-patcher
csi-baremetal-se-tbq7q
              app.kubernetes.io/component=se
              component=se
```
