### PR TITLE
[ISSUE-808] Set custom values for codecov badge color limits

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,4 +1,7 @@
 coverage:
+  range: 70..85
+  round: down
+  precision: 2
   status:
     project:
       default:


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#808

Update color limits to
- 70% - yellow
- 85% - green


## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved
