### PR TITLE
[ISSUE-885] Fix CSINode Pod Crash When Atlantic Cluster Scale Down and then Scale Up

### DIFF
--- a/pkg/nodeoperations/controller.go
+++ b/pkg/nodeoperations/controller.go
@@ -83,7 +83,15 @@ func (c *Controller) Reconcile(ctx context.Context, csi *csibaremetalv1.Deployme
 		nodeSelector = csi.Spec.NodeSelector
 	}
 
-	nodes, err := common.GetSelectedNodes(ctx, c.clientset, nodeSelector)
+	var nodes corev1.NodeList
+	listOpts := &client.ListOptions{}
+
+	if nodeSelector != nil {
+		o := &client.ListOptions{LabelSelector: labels.SelectorFromSet(common.MakeNodeSelectorMap(nodeSelector))}
+		o.ApplyToList(listOpts)
+	}
+
+	err := c.client.List(ctx, &nodes, listOpts)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Issue dell/csi-baremetal#885

Change csi-baremetal-operator to use **sigs.k8s.io/controller-runtime/pkg/client** , the same lib used by csi-baremetal-node-controller, to query removed node to fix previous issue of inconsistent query result in this case.

## PR checklist
- [x] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Testing details_
