### PR TITLE
Secondary Scheduler Code Enhancement

### DIFF
--- a/api/v1/components/csi.go
+++ b/api/v1/components/csi.go
@@ -35,7 +35,6 @@ type DeploymentSpec struct {
 	NodeSelector             *NodeSelector `json:"nodeSelector,omitempty"`
 	NodeIDAnnotation         bool          `json:"nodeIDAnnotation,omitempty"`
 	SequentialLVGReservation bool          `json:"sequentialLVGReservation,omitempty"`
-	SecondaryScheduler       bool          `json:"secondaryScheduler,omitempty"`
 
 	// +kubebuilder:validation:Enum=rke;openshift;vanilla
 	// +kubebuilder:default:=vanilla

--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -19,7 +19,6 @@ spec:
     value: {{.Values.nodeSelector.value}}
   {{- end }}
   sequentialLVGReservation: {{ .Values.feature.sequentialLVGReservation }}
-  secondaryScheduler: {{ .Values.feature.secondaryScheduler }}
   driver:
     controller:
       image:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -23,8 +23,6 @@ feature:
   # need for node replacement and node removal features
   usenodeannotation: true
   useexternalannotation: false
-  # use secondary scheduler on Openshift, only valid for Openshift
-  secondaryScheduler: true
   nodeIDAnnotation:
 
 # to deploy on specific nodes kubeclt get nodes -l <key>=<value>

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_deployments.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_deployments.yaml
@@ -673,8 +673,6 @@ spec:
                 type: object
               sequentialLVGReservation:
                 type: boolean
-              secondaryScheduler:
-                type: boolean
             required:
             - platform
             - pullPolicy

--- a/pkg/patcher/extender_readiness.go
+++ b/pkg/patcher/extender_readiness.go
@@ -130,6 +130,17 @@ func (p *SchedulerPatcher) UpdateReadinessConfigMap(ctx context.Context, csi *cs
 	if err != nil {
 		return err
 	}
+	if csi.Spec.Platform == constant.PlatformOpenShift {
+		useSecondaryScheduler, err := p.useSecondaryScheduler()
+		if err != nil {
+			return err
+		} else if useSecondaryScheduler {
+			options.watchedConfigMapName = csiOpenshiftSecondarySchedulerConfig
+			options.watchedConfigMapNamespace = openshiftSecondarySchedulerNamespace
+			options.kubeSchedulerLabel = fmt.Sprintf("%s=%s", openshiftSecondarySchedulerLabelKey,
+				openshiftSecondarySchedulerLabelValue)
+		}
+	}
 
 	cmCreationTime, err := p.getConfigMapCreationTime(ctx, options)
 	if err != nil {

--- a/pkg/patcher/extender_readiness.go
+++ b/pkg/patcher/extender_readiness.go
@@ -190,7 +190,11 @@ func (p *SchedulerPatcher) UpdateReadinessConfigMap(ctx context.Context, csi *cs
 		p.Log.Info("Retry patching")
 		switch csi.Spec.Platform {
 		case constant.PlatformOpenShift:
-			err = p.retryPatchOpenshift(ctx, csi)
+			if useOpenshiftSecondaryScheduler {
+				err = p.retryPatchOpenshiftSecondaryScheduler(ctx, csi)
+			} else {
+				err = p.retryPatchOpenshift(ctx, csi)
+			}
 			return err
 		case constant.PlatformVanilla, constant.PlatformRKE:
 			err = p.retryPatchVanilla(ctx, csi, scheme)

--- a/pkg/patcher/extender_readiness_test.go
+++ b/pkg/patcher/extender_readiness_test.go
@@ -348,10 +348,9 @@ func prepareValidatorClient(scheme *runtime.Scheme, objects ...client.Object) cl
 
 func prepareSchedulerPatcher(eventRecorder events.EventRecorder, clientSet kubernetes.Interface, client client.Client) *SchedulerPatcher {
 	sp := &SchedulerPatcher{
-		clientSet,
-		logEntry,
-		nil,
-		securityverifier.NewPodSecurityPolicyVerifier(
+		Clientset: clientSet,
+		Log:       logEntry,
+		PodSecurityPolicyVerifier: securityverifier.NewPodSecurityPolicyVerifier(
 			validator.NewValidator(rbac.NewValidator(
 				client,
 				logEntry,

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -22,8 +22,8 @@ type SchedulerPatcher struct {
 	PodSecurityPolicyVerifier securityverifier.SecurityVerifier
 	// SelectedSchedulerExtenderIP used for openshift secondary scheduler extender config if applicable
 	SelectedSchedulerExtenderIP string
-	// httpClient used for openshift secondary scheduler extender config if applicable
-	httpClient *http.Client
+	// HttpClient used for openshift secondary scheduler extender config if applicable
+	HttpClient *http.Client
 }
 
 // Update updates or creates csi-baremetal-se-patcher on RKE and Vanilla

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -2,6 +2,7 @@ package patcher
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,8 +20,10 @@ type SchedulerPatcher struct {
 	Log                       *logrus.Entry
 	Client                    client.Client
 	PodSecurityPolicyVerifier securityverifier.SecurityVerifier
-	// OpenshiftMasterNodeIP used for openshift secondary scheduler extender config if applicable
-	OpenshiftMasterNodeIP string
+	// SelectedSchedulerExtenderIP used for openshift secondary scheduler extender config if applicable
+	SelectedSchedulerExtenderIP string
+	// httpClient used for openshift secondary scheduler extender config if applicable
+	httpClient *http.Client
 }
 
 // Update updates or creates csi-baremetal-se-patcher on RKE and Vanilla

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -47,6 +47,7 @@ func (p *SchedulerPatcher) useSecondaryScheduler() (bool, error) {
 				return false, err
 			}
 			p.KubernetesVersion = fmt.Sprintf("%d.%d", k8sMajorVersion, k8sMinorVersion)
+			p.Log.Infof("Kubernetes version: %s", p.KubernetesVersion)
 			p.UseSecondaryScheduler = k8sMajorVersion == 1 && k8sMinorVersion > 22
 		} else {
 			return false, err

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -339,7 +339,7 @@ func (p *SchedulerPatcher) uninstallSecondaryScheduler(ctx context.Context) erro
 		return err
 	}
 
-	p.Client.Delete(ctx, secondaryScheduler)
+	err = p.Client.Delete(ctx, secondaryScheduler)
 	if err != nil {
 		return err
 	}

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -130,7 +130,7 @@ extenders:
 	}
 
 	// try to patch
-	err = p.updateSecondaryScheduler(ctx, openshiftConfig)
+	err = p.updateSecondaryScheduler(ctx)
 	if err != nil {
 		p.Log.Error(err, "Failed to patch Scheduler")
 		return err
@@ -262,7 +262,7 @@ func createOpenshiftConfig(policy string) *corev1.ConfigMap {
 	}
 }
 
-func (p *SchedulerPatcher) updateSecondaryScheduler(ctx context.Context, config string) error {
+func (p *SchedulerPatcher) updateSecondaryScheduler(ctx context.Context) error {
 	secondaryScheduler := &ssv1.SecondaryScheduler{}
 
 	err := p.Client.Get(ctx, client.ObjectKey{Name: "cluster",

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -269,6 +269,7 @@ func (p *SchedulerPatcher) updateSecondaryScheduler(ctx context.Context, config 
 		Namespace: openshiftSecondarySchedulerNamespace}, secondaryScheduler)
 	if err != nil {
 		if k8sError.IsNotFound(err) {
+			// TODO make scheduler image version dependent on platform's k8s version
 			secondaryScheduler = &ssv1.SecondaryScheduler{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -276,16 +277,16 @@ func (p *SchedulerPatcher) updateSecondaryScheduler(ctx context.Context, config 
 					Namespace: openshiftSecondarySchedulerNamespace,
 				},
 				Spec: ssv1.SecondarySchedulerSpec{
-					//OperatorSpec: oov1.OperatorSpec{
-					//	ManagementState:  "Managed",
-					//	OperatorLogLevel: "Normal",
-					//	LogLevel:         "Normal",
-					//},
 					SchedulerConfig: csiOpenshiftSecondarySchedulerConfig,
-					// TODO make scheduler image version dependent on platform's k8s version
-					SchedulerImage: csiOpenshiftSecondarySchedulerImage,
+					SchedulerImage:  csiOpenshiftSecondarySchedulerImage,
 				},
 			}
+
+			//OperatorSpec: oov1.OperatorSpec{
+			//	ManagementState:  "Managed",
+			//	OperatorLogLevel: "Normal",
+			//	LogLevel:         "Normal",
+			//},
 
 			err = p.Client.Create(ctx, secondaryScheduler)
 			if err != nil {

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -32,8 +32,8 @@ const (
 )
 
 func (p *SchedulerPatcher) schedulerExtenderWorkable(ip string, port string) (bool, error) {
-	if p.httpClient == nil {
-		p.httpClient = &http.Client{Timeout: 5 * time.Second}
+	if p.HttpClient == nil {
+		p.HttpClient = &http.Client{Timeout: 5 * time.Second}
 	}
 	extenderFilterUrl := fmt.Sprintf("http://%s:%s/filter", ip, port)
 	request, err := http.NewRequest(http.MethodGet, extenderFilterUrl, nil)
@@ -41,7 +41,7 @@ func (p *SchedulerPatcher) schedulerExtenderWorkable(ip string, port string) (bo
 		return false, err
 	}
 	request.Header.Add("Accept", "application/json")
-	response, err := p.httpClient.Do(request)
+	response, err := p.HttpClient.Do(request)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -45,6 +45,7 @@ func (p *SchedulerPatcher) schedulerExtenderWorkable(ip string, port string) (bo
 	if err != nil {
 		return false, err
 	}
+	defer response.Body.Close()
 	if response.StatusCode == http.StatusOK {
 		return true, nil
 	}

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -241,6 +241,21 @@ func (p *SchedulerPatcher) retryPatchOpenshift(ctx context.Context, csi *csibare
 	return nil
 }
 
+func (p *SchedulerPatcher) retryPatchOpenshiftSecondaryScheduler(ctx context.Context, csi *csibaremetalv1.Deployment) error {
+	err := p.unPatchOpenShiftSecondaryScheduler(ctx)
+	if err != nil {
+		p.Log.Error(err, "Failed to unpatch Openshift Secondary Scheduler")
+		return err
+	}
+
+	err = p.patchOpenShiftSecondaryScheduler(ctx, csi)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func createSecondarySchedulerConfig(config string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{},

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -27,7 +27,7 @@ const (
 
 	openshiftPolicyFile = "policy.cfg"
 
-	openshiftSchedulerResourceName        = "cluster"
+	// openshiftSchedulerResourceName        = "cluster"
 	openshiftSecondarySchedulerLabelKey   = "app"
 	openshiftSecondarySchedulerLabelValue = "secondary-scheduler"
 	openshiftSecondarySchedulerNamespace  = "openshift-secondary-scheduler-operator"
@@ -265,14 +265,14 @@ func createOpenshiftConfig(policy string) *corev1.ConfigMap {
 func (p *SchedulerPatcher) updateSecondaryScheduler(ctx context.Context, config string) error {
 	secondaryScheduler := &ssv1.SecondaryScheduler{}
 
-	err := p.Client.Get(ctx, client.ObjectKey{Name: openshiftSchedulerResourceName,
+	err := p.Client.Get(ctx, client.ObjectKey{Name: "cluster",
 		Namespace: openshiftSecondarySchedulerNamespace}, secondaryScheduler)
 	if err != nil {
 		if k8sError.IsNotFound(err) {
 			secondaryScheduler = &ssv1.SecondaryScheduler{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      openshiftSchedulerResourceName,
+					Name:      "cluster",
 					Namespace: openshiftSecondarySchedulerNamespace,
 				},
 				Spec: ssv1.SecondarySchedulerSpec{
@@ -342,7 +342,7 @@ func (p *SchedulerPatcher) patchScheduler(ctx context.Context, config string) er
 func (p *SchedulerPatcher) uninstallSecondaryScheduler(ctx context.Context) error {
 	secondaryScheduler := &ssv1.SecondaryScheduler{}
 
-	err := p.Client.Get(ctx, client.ObjectKey{Name: openshiftSchedulerResourceName,
+	err := p.Client.Get(ctx, client.ObjectKey{Name: "cluster",
 		Namespace: openshiftSecondarySchedulerNamespace}, secondaryScheduler)
 	if err != nil {
 		return err

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -227,9 +226,4 @@ func createExtenderSecurityContext(ctx *components.SecurityContext) *corev1.Secu
 	return &corev1.SecurityContext{
 		Privileged: ctx.Privileged,
 	}
-}
-
-// GetSchedulerExtenderDaemonsetPodsSelector returns a label-selector to use in the List method
-func GetSchedulerExtenderDaemonsetPodsSelector() labels.Selector {
-	return labels.SelectorFromSet(common.ConstructSelectorMap(extenderName))
 }

--- a/pkg/scheduler_extender.go
+++ b/pkg/scheduler_extender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -226,4 +227,9 @@ func createExtenderSecurityContext(ctx *components.SecurityContext) *corev1.Secu
 	return &corev1.SecurityContext{
 		Privileged: ctx.Privileged,
 	}
+}
+
+// GetSchedulerExtenderDaemonsetPodsSelector returns a label-selector to use in the List method
+func GetSchedulerExtenderDaemonsetPodsSelector() labels.Selector {
+	return labels.SelectorFromSet(common.ConstructSelectorMap(extenderName))
 }


### PR DESCRIPTION
## Purpose
1. Check whether extender workable; if unworkable, use another extender
2. Whether to use openshift secondary scheduler depends on detected k8s version
3. Scheduler extender readiness checks whether configuration applied to 2nd scheduler
4. Support CSI install on existing openshift secondary scheduler
5. retryPatchOpenshiftSecondaryScheduler

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
_Testing details_
