### PR TITLE
[ISSUE-950] Openshift 4.12 Scheduler Extender Sometimes Stuck in Not Ready Status

### DIFF
--- a/pkg/patcher/extender_readiness.go
+++ b/pkg/patcher/extender_readiness.go
@@ -26,6 +26,9 @@ const (
 	ExtenderConfigMapFile = "nodes.yaml"
 
 	K8sMasterNodeLabelKey = "node-role.kubernetes.io/master"
+
+	readinessCheckIntervalForOpenshiftSecondaryScheduler = 10 * time.Second
+	readinessMaxRetiresForOpenshiftSecondaryScheduler    = 12
 )
 
 // ExtenderReadinessOptions contains options to deploy ExtenderConfigMap
@@ -148,8 +151,8 @@ func (p *SchedulerPatcher) UpdateReadinessConfigMap(ctx context.Context, csi *cs
 
 	var readinessStatuses *ReadinessStatusList
 	if useOpenshiftSecondaryScheduler {
-		readinessStatuses, err = p.updateReadinessStatusesForOpenshiftSecondaryScheduler(ctx,
-			options.kubeSchedulerLabel, cmCreationTime, 10*time.Second, 12)
+		readinessStatuses, err = p.updateReadinessStatusesForOpenshiftSecondaryScheduler(ctx, options.kubeSchedulerLabel,
+			cmCreationTime, readinessCheckIntervalForOpenshiftSecondaryScheduler, readinessMaxRetiresForOpenshiftSecondaryScheduler)
 	} else {
 		readinessStatuses, err = p.updateReadinessStatuses(ctx, options.kubeSchedulerLabel, cmCreationTime)
 	}

--- a/pkg/patcher/extender_readiness.go
+++ b/pkg/patcher/extender_readiness.go
@@ -149,7 +149,7 @@ func (p *SchedulerPatcher) UpdateReadinessConfigMap(ctx context.Context, csi *cs
 	var readinessStatuses *ReadinessStatusList
 	if useOpenshiftSecondaryScheduler {
 		readinessStatuses, err = p.updateReadinessStatusesForOpenshiftSecondaryScheduler(ctx,
-			options.kubeSchedulerLabel, cmCreationTime, 10*time.Second, 30)
+			options.kubeSchedulerLabel, cmCreationTime, 10*time.Second, 12)
 	} else {
 		readinessStatuses, err = p.updateReadinessStatuses(ctx, options.kubeSchedulerLabel, cmCreationTime)
 	}

--- a/pkg/patcher/extender_readiness_test.go
+++ b/pkg/patcher/extender_readiness_test.go
@@ -233,6 +233,75 @@ func Test_createReadinessConfigMap(t *testing.T) {
 	})
 }
 
+func Test_updateReadinessStatusesForOpenshiftSecondaryScheduler(t *testing.T) {
+	t.Run("Test updateReadinessStatusesForOpenshiftSecondaryScheduler", func(t *testing.T) {
+		eventRecorder := new(mocks.EventRecorder)
+		eventRecorder.On("Eventf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+		scheme, _ := common.PrepareScheme()
+		ctx := context.Background()
+		curTime := time.Now()
+
+		nodeTemplate := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "master",
+				Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+			},
+			Spec: corev1.NodeSpec{},
+		}
+		node0 := nodeTemplate.DeepCopy()
+		node0.Name = node0.Name + "0"
+		node1 := nodeTemplate.DeepCopy()
+		node1.Name = node1.Name + "1"
+
+		sp := prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(node0, node1),
+			prepareValidatorClient(scheme, node0, node1))
+
+		statuses, err := sp.updateReadinessStatusesForOpenshiftSecondaryScheduler(ctx,
+			"app=secondary-scheduler", metav1.Time{Time: curTime}, time.Second, 6)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(statuses.Items))
+		for _, status := range statuses.Items {
+			assert.Empty(t, status.KubeScheduler)
+			assert.True(t, status.Restarted)
+			assert.True(t, status.NodeName == "master0" || status.NodeName == "master1")
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secondary-scheduler",
+				Namespace: OpenshiftSecondarySchedulerNamespace,
+				Labels:    map[string]string{"app": "secondary-scheduler"},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{
+								Time: curTime,
+							},
+						},
+					}},
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "worker0",
+			},
+		}
+		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(pod, node0, node1),
+			prepareValidatorClient(scheme, pod, node0, node1))
+
+		statuses, err = sp.updateReadinessStatusesForOpenshiftSecondaryScheduler(ctx,
+			"app=secondary-scheduler", metav1.Time{Time: curTime}, time.Second, 6)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(statuses.Items))
+		for _, status := range statuses.Items {
+			assert.Equal(t, pod.Name, status.KubeScheduler)
+			assert.True(t, status.Restarted)
+			assert.True(t, status.NodeName == "master0" || status.NodeName == "master1")
+		}
+	})
+}
+
 func Test_updateReadinessStatuses(t *testing.T) {
 	var (
 		ctx         = context.Background()

--- a/pkg/patcher/extender_readiness_test.go
+++ b/pkg/patcher/extender_readiness_test.go
@@ -282,8 +282,7 @@ func Test_updateReadinessStatuses(t *testing.T) {
 		scheme, _ := common.PrepareScheme()
 		sp := prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(pod1, pod2, pod3), prepareValidatorClient(scheme, pod1, pod2, pod3))
 
-		statuses, err := sp.updateReadinessStatuses(ctx, "component=kube-scheduler",
-			metav1.Time{Time: curTime}, false)
+		statuses, err := sp.updateReadinessStatuses(ctx, "component=kube-scheduler", metav1.Time{Time: curTime})
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(statuses.Items))
 


### PR DESCRIPTION
Signed-off-by: Shi, Crane <crane.shi@emc.com>

## Purpose
### Issue dell/csi-baremetal#950

Fix the issue that Openshift 4.12 Scheduler Extender Sometimes Stuck in Not Ready Status

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
I have successfully re-deployed CSI using the CSI operator image 1.1.0-114.7b6e96e, built from the latest commit in this PR, multiple times and never see this issue again.
custom CI using this CSI operator image passed: https://asd-ecs-jenkins.isus.emc.com/view/Atlantic/job/csi-custom-ci/1520/
custom acceptance on Openshift 4.12 using this CSI operator image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-goop_a/31/
custom acceptance on Atlantic using this CSI operator image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-tar_a/214/
