### PR TITLE
[ISSUE-955] Enhance Openshift 4.12 Support

### DIFF
--- a/api/v1/components/openshift_secondary_scheduler.go
+++ b/api/v1/components/openshift_secondary_scheduler.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+// OpenshiftSecondaryScheduler represents information to deploy Openshift Secondary Scheduler if applicable
+type OpenshiftSecondaryScheduler struct {
+	Image *Image `json:"image,omitempty"`
+}

--- a/api/v1/components/scheduler.go
+++ b/api/v1/components/scheduler.go
@@ -26,6 +26,8 @@ type Scheduler struct {
 	Patcher            *Patcher `json:"patcher,omitempty"`
 	ExtenderPort       string   `json:"extenderPort,omitempty"`
 	StorageProvisioner string   `json:"storageProvisioner"`
+
+	OpenshiftSecondaryScheduler *OpenshiftSecondaryScheduler `json:"openshiftSecondaryScheduler,omitempty"`
 	// +nullable
 	// +optional
 	Resources         *ResourceRequirements `json:"resources,omitempty"`

--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -128,10 +128,16 @@ spec:
       configMapName: {{ .Values.scheduler.patcher.config_map_name }}
       readinessTimeout: {{ .Values.scheduler.patcher.readinessTimeout }}
     storageProvisioner: {{ .Values.scheduler.provisioner }}
+    {{- if .Values.scheduler.openshiftSecondaryScheduler }}
     openshiftSecondaryScheduler:
       image:
+        {{- if .Values.scheduler.openshiftSecondaryScheduler.image.name }}
         name: {{ .Values.scheduler.openshiftSecondaryScheduler.image.name }}
+        {{- end }}
+        {{- if .Values.scheduler.openshiftSecondaryScheduler.image.tag }}
         tag: {{ .Values.scheduler.openshiftSecondaryScheduler.image.tag }}
+        {{- end }}
+    {{- end }}
     {{- if .Values.scheduler.securityContext.enable }}
     securityContext:
       enable: {{ .Values.scheduler.securityContext.enable }}

--- a/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
+++ b/charts/csi-baremetal-deployment/templates/csi-baremetal_v1_deployment.yaml
@@ -128,6 +128,10 @@ spec:
       configMapName: {{ .Values.scheduler.patcher.config_map_name }}
       readinessTimeout: {{ .Values.scheduler.patcher.readinessTimeout }}
     storageProvisioner: {{ .Values.scheduler.provisioner }}
+    openshiftSecondaryScheduler:
+      image:
+        name: {{ .Values.scheduler.openshiftSecondaryScheduler.image.name }}
+        tag: {{ .Values.scheduler.openshiftSecondaryScheduler.image.tag }}
     {{- if .Values.scheduler.securityContext.enable }}
     securityContext:
       enable: {{ .Values.scheduler.securityContext.enable }}

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -219,10 +219,11 @@ scheduler:
   # extender will be looking for volumes that should be provisioned
   # by storage class with provided provisioner name
   provisioner: csi-baremetal
-  openshiftSecondaryScheduler:
-    image:
-      name: kube-scheduler
-      tag: v0.23.10
+  # properties for openshift secondary scheduler if applicable
+  # openshiftSecondaryScheduler:
+  #   image:
+  #     name: kube-scheduler
+  #     tag: v0.23.10
 
 # CSI Operator parameters
 nodeController:

--- a/charts/csi-baremetal-deployment/values.yaml
+++ b/charts/csi-baremetal-deployment/values.yaml
@@ -219,6 +219,10 @@ scheduler:
   # extender will be looking for volumes that should be provisioned
   # by storage class with provided provisioner name
   provisioner: csi-baremetal
+  openshiftSecondaryScheduler:
+    image:
+      name: kube-scheduler
+      tag: v0.23.10
 
 # CSI Operator parameters
 nodeController:

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_deployments.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_deployments.yaml
@@ -548,6 +548,23 @@ spec:
                     - path
                     - port
                     type: object
+                  openshiftSecondaryScheduler:
+                    description: OpenshiftSecondaryScheduler represents information
+                      to deploy Openshift Secondary Scheduler if applicable
+                    properties:
+                      image:
+                        description: Image contain information for components docker
+                          images
+                        properties:
+                          name:
+                            type: string
+                          tag:
+                            type: string
+                        required:
+                        - name
+                        - tag
+                        type: object
+                    type: object
                   patcher:
                     description: Patcher represents scheduler patcher container, which
                       tries to patch Kubernetes scheduler

--- a/pkg/patcher/extender_readiness.go
+++ b/pkg/patcher/extender_readiness.go
@@ -180,7 +180,7 @@ func (p *SchedulerPatcher) UpdateReadinessConfigMap(ctx context.Context, csi *cs
 		p.Log.Info("Retry patching")
 		switch csi.Spec.Platform {
 		case constant.PlatformOpenShift:
-			err = p.retryPatchOpenshift(ctx, csi, useOpenshiftSecondaryScheduler)
+			err = p.retryPatchOpenshift(ctx, csi, useOpenshiftSecondaryScheduler, scheme)
 			return err
 		case constant.PlatformVanilla, constant.PlatformRKE:
 			err = p.retryPatchVanilla(ctx, csi, scheme)

--- a/pkg/patcher/scheduler_patcher.go
+++ b/pkg/patcher/scheduler_patcher.go
@@ -77,7 +77,7 @@ func (p *SchedulerPatcher) Update(ctx context.Context, csi *csibaremetalv1.Deplo
 	}
 	switch csi.Spec.Platform {
 	case constant.PlatformOpenShift:
-		err = p.patchOpenShift(ctx, csi, useOpenshiftSecondaryScheduler)
+		err = p.patchOpenShift(ctx, csi, useOpenshiftSecondaryScheduler, scheme)
 	case constant.PlatformVanilla, constant.PlatformRKE:
 		err = p.updateVanilla(ctx, csi, scheme)
 	}

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -36,7 +36,6 @@ const (
 	openshiftSecondarySchedulerDataKey   = "config.yaml"
 
 	csiOpenshiftSecondarySchedulerConfigMapName = "csi-baremetal-scheduler-config"
-	csiOpenshiftSecondarySchedulerImage         = "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.23.10"
 
 	csiExtenderName = constant.CSIName + "-se"
 
@@ -167,7 +166,7 @@ func (p *SchedulerPatcher) patchOpenShift(ctx context.Context, csi *csibaremetal
 
 	// try to patch
 	if useOpenshiftSecondaryScheduler {
-		_, err = p.patchSecondaryScheduler(ctx)
+		_, err = p.patchSecondaryScheduler(ctx, csi)
 	} else {
 		err = p.patchScheduler(ctx, openshiftSchedulerPolicyConfigMapName)
 	}
@@ -263,8 +262,11 @@ func createOpenshiftConfigMapObject(config string, useOpenshiftSecondarySchedule
 	}
 }
 
-func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context) (*ssv1.SecondaryScheduler, error) {
+func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csibaremetalv1.Deployment) (*ssv1.SecondaryScheduler, error) {
 	secondaryScheduler := &ssv1.SecondaryScheduler{}
+	csiOpenshiftSecondarySchedulerImage := common.ConstructFullImageName(
+		csi.Spec.Scheduler.OpenshiftSecondaryScheduler.Image, csi.Spec.GlobalRegistry)
+
 	err := p.Client.Get(ctx, client.ObjectKey{Name: openshiftSchedulerResourceName,
 		Namespace: OpenshiftSecondarySchedulerNamespace}, secondaryScheduler)
 	if err != nil {

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -47,6 +47,7 @@ const (
 	extenderFilterPattern   = "/filter"
 
 	existing3rdPartySecondarySchedulerErrMsg = "existing 3rd-party secondary scheduler"
+	invalidSecondarySchedulerImgErrMsg       = "invalid secondary scheduler image provided"
 )
 
 func (p *SchedulerPatcher) checkSchedulerExtender(ip string, port string) error {
@@ -272,8 +273,13 @@ func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csi
 	secondaryScheduler := &ssv1.SecondaryScheduler{}
 
 	var csiOpenshiftSecondarySchedulerImage *components.Image
-	if csi.Spec.Scheduler.OpenshiftSecondaryScheduler != nil && csi.Spec.Scheduler.OpenshiftSecondaryScheduler.Image != nil {
+	csiOpenshiftSecondaryScheduler := csi.Spec.Scheduler.OpenshiftSecondaryScheduler
+	if csiOpenshiftSecondaryScheduler != nil && csiOpenshiftSecondaryScheduler.Image != nil {
 		csiOpenshiftSecondarySchedulerImage = csi.Spec.Scheduler.OpenshiftSecondaryScheduler.Image
+		if csiOpenshiftSecondarySchedulerImage.Name == "" || csiOpenshiftSecondarySchedulerImage.Tag == "" {
+			p.Log.Error(invalidSecondarySchedulerImgErrMsg)
+			return nil, errors.New(invalidSecondarySchedulerImgErrMsg)
+		}
 	} else {
 		csiOpenshiftSecondarySchedulerImage = &components.Image{
 			Name: openshiftSecondarySchedulerDefaultImageName,

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -269,7 +269,8 @@ func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csi
 
 	err := p.Client.Get(ctx, client.ObjectKey{Name: openshiftSchedulerResourceName,
 		Namespace: OpenshiftSecondarySchedulerNamespace}, secondaryScheduler)
-	if err != nil {
+	switch {
+	case err != nil:
 		if k8sError.IsNotFound(err) {
 			// TODO make scheduler image version dependent on platform's k8s version
 			secondaryScheduler = &ssv1.SecondaryScheduler{
@@ -296,10 +297,10 @@ func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csi
 			return secondaryScheduler, nil
 		}
 		return nil, err
-	} else if secondaryScheduler.Spec.SchedulerConfig != csiOpenshiftSecondarySchedulerConfigMapName {
+	case secondaryScheduler.Spec.SchedulerConfig != csiOpenshiftSecondarySchedulerConfigMapName:
 		p.Log.Error("Existing 3rd-party secondary scheduler! Baremetal CSI will not be installed!")
-		return nil, errors.New("Existing 3rd-party secondary scheduler")
-	} else if secondaryScheduler.Spec.SchedulerImage != csiOpenshiftSecondarySchedulerImage {
+		return nil, errors.New("existing 3rd-party secondary scheduler")
+	case secondaryScheduler.Spec.SchedulerImage != csiOpenshiftSecondarySchedulerImage:
 		secondaryScheduler.Spec.SchedulerImage = csiOpenshiftSecondarySchedulerImage
 		if err = p.Client.Update(ctx, secondaryScheduler); err != nil {
 			return nil, err

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -101,9 +101,9 @@ func (p *SchedulerPatcher) getSchedulerExtenderIP(ctx context.Context, csi *csib
 	if err == nil {
 		selectedSchedulerExtenderIP := selectedSchedulerExtenderIPConfigMap.Data[selectedSchedulerExtenderIPConfigMapDataKey]
 		if selectedSchedulerExtenderIP != p.SelectedSchedulerExtenderIP {
-			if err1 := p.checkSchedulerExtender(selectedSchedulerExtenderIP, extenderPort); err != nil {
+			if err = p.checkSchedulerExtender(selectedSchedulerExtenderIP, extenderPort); err != nil {
 				p.Log.Warnf("selectedSchedulerExtenderIPConfigMap's IP %s doesn't work: %s",
-					selectedSchedulerExtenderIP, err1.Error())
+					selectedSchedulerExtenderIP, err.Error())
 			} else {
 				p.SelectedSchedulerExtenderIP = selectedSchedulerExtenderIP
 				return p.SelectedSchedulerExtenderIP, nil

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -47,7 +47,6 @@ const (
 	extenderFilterPattern   = "/filter"
 
 	existing3rdPartySecondarySchedulerErrMsg = "existing 3rd-party secondary scheduler"
-	invalidSecondarySchedulerImgErrMsg       = "invalid secondary scheduler image provided"
 )
 
 func (p *SchedulerPatcher) checkSchedulerExtender(ip string, port string) error {
@@ -277,8 +276,11 @@ func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csi
 	if csiOpenshiftSecondaryScheduler != nil && csiOpenshiftSecondaryScheduler.Image != nil {
 		csiOpenshiftSecondarySchedulerImage = csi.Spec.Scheduler.OpenshiftSecondaryScheduler.Image
 		if csiOpenshiftSecondarySchedulerImage.Name == "" || csiOpenshiftSecondarySchedulerImage.Tag == "" {
-			p.Log.Error(invalidSecondarySchedulerImgErrMsg)
-			return nil, errors.New(invalidSecondarySchedulerImgErrMsg)
+			p.Log.Warn("Invalid secondary scheduler image provided! Use default secondary scheduler image instead!")
+			csiOpenshiftSecondarySchedulerImage = &components.Image{
+				Name: openshiftSecondarySchedulerDefaultImageName,
+				Tag:  openshiftSecondarySchedulerDefaultImageTag,
+			}
 		}
 	} else {
 		csiOpenshiftSecondarySchedulerImage = &components.Image{

--- a/pkg/patcher/scheduler_patcher_openshift.go
+++ b/pkg/patcher/scheduler_patcher_openshift.go
@@ -41,6 +41,8 @@ const (
 
 	extenderFilterURLFormat = "http://%s:%s%s"
 	extenderFilterPattern   = "/filter"
+
+	existing3rdPartySecondarySchedulerErrMsg = "existing 3rd-party secondary scheduler"
 )
 
 func (p *SchedulerPatcher) checkSchedulerExtender(ip string, port string) error {
@@ -299,7 +301,7 @@ func (p *SchedulerPatcher) patchSecondaryScheduler(ctx context.Context, csi *csi
 		return nil, err
 	case secondaryScheduler.Spec.SchedulerConfig != csiOpenshiftSecondarySchedulerConfigMapName:
 		p.Log.Error("Existing 3rd-party secondary scheduler! Baremetal CSI will not be installed!")
-		return nil, errors.New("existing 3rd-party secondary scheduler")
+		return nil, errors.New(existing3rdPartySecondarySchedulerErrMsg)
 	case secondaryScheduler.Spec.SchedulerImage != csiOpenshiftSecondarySchedulerImage:
 		secondaryScheduler.Spec.SchedulerImage = csiOpenshiftSecondarySchedulerImage
 		if err = p.Client.Update(ctx, secondaryScheduler); err != nil {

--- a/pkg/patcher/scheduler_patcher_openshift_test.go
+++ b/pkg/patcher/scheduler_patcher_openshift_test.go
@@ -29,13 +29,20 @@ var (
 			Namespace: ns,
 		},
 		Spec: components.DeploymentSpec{
-			Platform: constant.PlatformOpenShift,
+			GlobalRegistry: "asdrepo.isus.emc.com:9042",
+			Platform:       constant.PlatformOpenShift,
 			Scheduler: &components.Scheduler{
 				Patcher: &components.Patcher{
 					Enable:        true,
 					ConfigMapName: schedulerConf,
 				},
 				ExtenderPort: "8889",
+				OpenshiftSecondaryScheduler: &components.OpenshiftSecondaryScheduler{
+					Image: &components.Image{
+						Name: "kube-scheduler",
+						Tag:  "v0.23.10",
+					},
+				},
 			},
 		},
 	}
@@ -243,16 +250,18 @@ func Test_patchSecondaryScheduler(t *testing.T) {
 		eventRecorder.On("Eventf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 		scheme, _ := common.PrepareScheme()
 		ctx := context.Background()
+		csiOpenshiftSecondarySchedulerImage := common.ConstructFullImageName(
+			csiDeploy.Spec.Scheduler.OpenshiftSecondaryScheduler.Image, csiDeploy.Spec.GlobalRegistry)
 
 		// case that creates new SecondaryScheduler CR cluster
 		sp := prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme))
-		secondarySchduler, err := sp.patchSecondaryScheduler(ctx)
+		secondarySchduler, err := sp.patchSecondaryScheduler(ctx, csiDeploy)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)
 
 		// case of no update on existing SecondaryScheduler CR cluster
-		secondarySchduler, err = sp.patchSecondaryScheduler(ctx)
+		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)
@@ -260,14 +269,14 @@ func Test_patchSecondaryScheduler(t *testing.T) {
 		// cases that try to update existing SecondaryScheduler CR cluster
 		secondarySchduler.Spec.SchedulerConfig = "config"
 		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme, secondarySchduler))
-		secondarySchduler, err = sp.patchSecondaryScheduler(ctx)
+		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)
 
 		secondarySchduler.Spec.SchedulerImage = "image"
 		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme, secondarySchduler))
-		secondarySchduler, err = sp.patchSecondaryScheduler(ctx)
+		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)

--- a/pkg/patcher/scheduler_patcher_openshift_test.go
+++ b/pkg/patcher/scheduler_patcher_openshift_test.go
@@ -266,20 +266,21 @@ func Test_patchSecondaryScheduler(t *testing.T) {
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)
 
-		// cases that try to update existing SecondaryScheduler CR cluster
-		secondarySchduler.Spec.SchedulerConfig = "config"
-		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme, secondarySchduler))
-		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
-		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
-		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
-		assert.Nil(t, err)
-
+		// case that update existing csi-baremetal secondary scheduler with different kube-scheduler image
 		secondarySchduler.Spec.SchedulerImage = "image"
 		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme, secondarySchduler))
 		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerConfigMapName, secondarySchduler.Spec.SchedulerConfig)
 		assert.Equal(t, csiOpenshiftSecondarySchedulerImage, secondarySchduler.Spec.SchedulerImage)
 		assert.Nil(t, err)
+
+		// cases that try to update on existing 3rd-party SecondaryScheduler CR cluster
+		secondarySchduler.Spec.SchedulerConfig = "config"
+		sp = prepareSchedulerPatcher(eventRecorder, prepareNodeClientSet(), prepareValidatorClient(scheme, secondarySchduler))
+		secondarySchduler, err = sp.patchSecondaryScheduler(ctx, csiDeploy)
+		assert.Nil(t, secondarySchduler)
+		assert.NotNil(t, err)
+		assert.Equal(t, existing3rdPartySecondarySchedulerErrMsg, err.Error())
 	})
 }
 


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#955

Enhance Openshift 4.12 Support:
a) Make openshift secondary scheduler image use CSI common images repo. Make the openshift secondary scheduler image configurable by helm charts parameters. If the openshift secondary scheduler image not provided externally, csi operator will used the default secondary scheduler image.
b) CSI will not be installed on existing 3rd-party secondary scheduler and the CSI removal also will not remove the existing 3rd-party secondary scheduler.
c) refine the logic of function getSchedulerExtenderIP to wait unitl any scheduler extender working to select new scheduler extender IP
d) refine the logic of function getSchedulerExtenderIP to try to get selected scheduler IP from existing config map before trying to get new scheduler extender IP

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
When manually deploying CSI using the CSI operator image 1.1.0-128.8e3c4b8, built from the latest commit in this PR, CSI deployment will use the secondary scheduler image from common CSI images repo. In addition, CSI will not be installed on existing 3rd-party secondary scheduler and the CSI removal also will not remove the existing 3rd-party secondary scheduler.

custom CI using this CSI operator image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-ci/1538/
custom acceptance on Openshift 4.12 using this CSI operator image passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance/656/
custom acceptance on Atlantic passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-tar_a/219/
