### PR TITLE
[ISSUE-996] csi-baremetal-pre-upgrade-crds CVES

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -11,7 +11,7 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 # image vars
 BASE_IMAGE ?= golang:1.17
 CRD_BUILD_IMAGE ?= ${REGISTRY}/csi-baremetal-pre-upgrade-crds:${TAG}
-KUBECTL_IMAGE ?=  bitnami/kubectl:latest # https://hub.docker.com/r/bitnami/kubectl
+KUBECTL_IMAGE ?=  bitnami/kubectl:1.25 # https://hub.docker.com/r/bitnami/kubectl
 
 ### version
 MAJOR            := 1

--- a/variables.mk
+++ b/variables.mk
@@ -11,7 +11,7 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 # image vars
 BASE_IMAGE ?= golang:1.17
 CRD_BUILD_IMAGE ?= ${REGISTRY}/csi-baremetal-pre-upgrade-crds:${TAG}
-KUBECTL_IMAGE ?=  bitnami/kubectl:1.23 # https://hub.docker.com/r/bitnami/kubectl
+KUBECTL_IMAGE ?=  bitnami/kubectl:latest # https://hub.docker.com/r/bitnami/kubectl
 
 ### version
 MAJOR            := 1


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#996

suggest to use latest kubectl image.
because this image is only used to execute command:
```sh
kubectl replace crd -f /crds
```
This subcommand will not change version by version in kubectl.
## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
