### PR TITLE
[ISSUE-1018] Refine Storage Group Feature on OBS Release 1.3 Branch

### DIFF
--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacities.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacities.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: availablecapacities.csi-baremetal.dell.com
 spec:
@@ -69,9 +68,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_availablecapacityreservations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: availablecapacityreservations.csi-baremetal.dell.com
 spec:
@@ -41,13 +40,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AvailableCapacityReservation is the Schema for the availablecapacitiereservations API
+        description: AvailableCapacityReservation is the Schema for the availablecapacitiereservations
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -98,9 +102,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_drives.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_drives.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: drives.csi-baremetal.dell.com
 spec:
@@ -79,10 +78,14 @@ spec:
         description: Drive is the Schema for the drives API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -141,9 +144,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_logicalvolumegroups.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: logicalvolumegroups.csi-baremetal.dell.com
 spec:
@@ -89,9 +88,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_nodes.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_nodes.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: nodes.csi-baremetal.dell.com
 spec:
@@ -64,9 +63,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_storagegroups.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_storagegroups.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: storagegroups.csi-baremetal.dell.com
 spec:
@@ -24,21 +23,14 @@ spec:
       jsonPath: .spec.driveSelector.numberDrivesPerNode
       name: DRIVES_PER_NODE
       type: string
-    - description: Drive Type of StorageGroup's DriveSelector
-      jsonPath: .spec.driveSelector.matchFields.Type
-      name: TYPE
+    - description: Match Fields of StorageGroup's DriveSelector to Select Drives on
+        Field Values
+      jsonPath: .spec.driveSelector.matchFields
+      name: DRIVE_FIELDS
       type: string
-    - description: Drive Slot of StorageGroup's DriveSelector
-      jsonPath: .spec.driveSelector.matchFields.Slot
-      name: SLOT
-      type: string
-    - description: Drive Path of StorageGroup's DriveSelector
-      jsonPath: .spec.driveSelector.matchFields.Path
-      name: PATH
-      type: string
-    - description: Whether StorageGroup's DriveSelector to Select System Drive
-      jsonPath: .spec.driveSelector.matchFields.IsSystem
-      name: SYSTEM
+    - description: status of StorageGroup
+      jsonPath: .status.phase
+      name: STATUS
       type: string
     name: v1
     schema:
@@ -46,10 +38,14 @@ spec:
         description: StorageGroup is the Schema for the StorageGroups API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -66,13 +62,15 @@ spec:
                     type: integer
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: updates to storagegroup spec are forbidden
+              rule: self == oldSelf
+          status:
+            properties:
+              phase:
+                type: string
+            type: object
         type: object
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_volumes.yaml
+++ b/charts/csi-baremetal-operator/crds/csi-baremetal.dell.com_volumes.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: volumes.csi-baremetal.dell.com
 spec:
@@ -62,10 +61,14 @@ spec:
         description: Volume is the Schema for the volumes API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -74,7 +77,8 @@ spec:
               CSIStatus:
                 type: string
               Ephemeral:
-                description: inline volumes are not support anymore. need to remove field in the next version
+                description: inline volumes are not support anymore. need to remove
+                  field in the next version
                 type: boolean
               Health:
                 type: string
@@ -110,9 +114,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal#1018

Refine Storage Group Feature CRD changes:
1) Add storagegroup.status
2) Add immutability validation rule to storagegroup.spec, i.e. block of storagegroup.spec update in crd validation.
3) To support immutablity validation rule in crd generation, upgrade controller-gen version to v0.9.2

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Manual test passed.
Custom CI passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-ci/1559/
Custom Acceptance Passed: https://asd-ecs-jenkins.isus.emc.com/job/csi-custom-acceptance-tar_b_ona/36/
