### PR TITLE
[ISSUE-223] Pull secret element misplaced in pre upgrade CRD template

### DIFF
--- a/charts/csi-baremetal-operator/templates/pre-upgrade-crds.yaml
+++ b/charts/csi-baremetal-operator/templates/pre-upgrade-crds.yaml
@@ -116,14 +116,14 @@ spec:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       containers:
         - name: "{{.Release.Namespace}}-{{.Release.Name}}-csi-baremetal-pre-crds-job"
           image: {{ if .Values.global.registry }}{{ .Values.global.registry }}/{{ end }}{{ .Values.preUpgradeCRDsHooks.image.name }}:{{ default .Values.image.tag .Values.preUpgradeCRDsHooks.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.preUpgradeCRDsHooks.image.pullPolicy }}
-          {{- if .Values.global.registrySecret }}
-          imagePullSecrets:
-            - name: {{ .Values.global.registrySecret }}
-          {{- end }}
           resources:
             limits:
               cpu: {{ .Values.operator.resources.limits.cpu }}


### PR DESCRIPTION
## Purpose
### Issue dell/csi-baremetal-operator#223

imagePullSecrets element nested under containers instead of directly under spec level.

## PR checklist
- [ ] Add link to the issue
- [ ] Choose Project
- [ ] Choose PR label
- [ ] New unit tests added
- [ ] Modified code has meaningful comments
- [ ] All TODOs are linked with the issues
- [ ] All comments are resolved

## Testing
Upgrade with  Values.global.registrySecret specified.
